### PR TITLE
ResponseがUTF8以外の時に文字コード変換等をしないようにする(Ruby1.9)

### DIFF
--- a/lib/jpmobile/rack/filter.rb
+++ b/lib/jpmobile/rack/filter.rb
@@ -22,10 +22,12 @@ module Jpmobile
           end
 
           body = response_to_body(response)
-          body = body.gsub(/<input name="utf8" type="hidden" value="#{[0x2713].pack("U")}"[^>]*?>/, ' ')
-          body = body.gsub(/<input name="utf8" type="hidden" value="&#x2713;"[^>]*?>/, ' ')
-
-          response, charset = mobile.to_external(body, type, charset)
+          if body.to_str.encoding == ::Encoding::UTF_8
+          # or unless body.to_str.encoding == ::Encoding::BINARY
+            body = body.gsub(/<input name="utf8" type="hidden" value="#{[0x2713].pack("U")}"[^>]*?>/, ' ')
+            body = body.gsub(/<input name="utf8" type="hidden" value="&#x2713;"[^>]*?>/, ' ')
+            response, charset = mobile.to_external(body, type, charset)
+          end
 
           if type and charset
             env['Content-Type'] = "#{type}; charset=#{charset}"


### PR DESCRIPTION
画像などのBinaryをResponseとして返せないのでgsubやto_external部分を回避するようにする．
