### PR TITLE
オーバーライン問題の修正

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -11,6 +11,9 @@ module Jpmobile
     WAVE_DASH = [0x301c].pack("U")
     FULLWIDTH_TILDE = [0xff5e].pack("U")
 
+    OVERLINE = [0x203e].pack("U")
+    FULLWIDTH_MACRON = [0xffe3].pack("U")
+
     module_function
     def deep_apply(obj, &proc)
       case obj
@@ -86,6 +89,9 @@ module Jpmobile
       # 波ダッシュ対策
       utf8_str = wavedash_to_fullwidth_tilde(utf8_str)
 
+      # オーバーライン対策
+      utf8_str = overline_to_fullwidth_macron(utf8_str)
+
       if utf8_str.respond_to?(:encode)
         utf8_str.encode(SJIS, :crlf_newline => true)
       else
@@ -101,7 +107,10 @@ module Jpmobile
                  end
 
       # 波ダッシュ対策
-      fullwidth_tilde_to_wavedash(utf8_str)
+      utf8_str = fullwidth_tilde_to_wavedash(utf8_str)
+
+      # オーバーライン対策
+      utf8_str = fullwidth_macron_to_overline(utf8_str)
     end
 
     def utf8_to_jis(utf8_str)
@@ -195,6 +204,14 @@ module Jpmobile
 
     def fullwidth_tilde_to_wavedash(utf8_str)
       utf8_str.gsub(FULLWIDTH_TILDE, WAVE_DASH)
+    end
+
+    def overline_to_fullwidth_macron(utf8_str)
+      utf8_str.gsub(OVERLINE, FULLWIDTH_MACRON)
+    end
+
+    def fullwidth_macron_to_overline(utf8_str)
+      utf8_str.gsub(FULLWIDTH_MACRON, OVERLINE)
     end
 
     def force_encode(str, from, to)

--- a/spec/rack/jpmobile/params_filter_spec.rb
+++ b/spec/rack/jpmobile/params_filter_spec.rb
@@ -10,11 +10,11 @@ describe Jpmobile::Rack::ParamsFilter do
     before(:each) do
       @query_params = {
         "hoge"       => "ほげ",
-        "パラメータ" => "テストです〜■",
+        "パラメータ" => "(‾_‾)y-~~~ テストです〜■",
       }
       @form_params = {
         "bar"        => "万葉集",
-        "アジャイル" => "僕の〜♪",
+        "アジャイル" => "(‾_‾)y-~~~ 僕の〜♪",
       }
     end
 


### PR DESCRIPTION
お世話になっております。

UnicodeのOVERLINE（‾）をShift_JISに変換しようとするとエラーが出ましたので修正致しました。
取り込めるようでしたら取り込んで頂けると幸いです。

修正内容
Shift_JISに変換する際にFULLWIDTH MACRONに置き換えて対処しています。
