### PR TITLE
emダッシュの変換エラー

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -14,6 +14,9 @@ module Jpmobile
     OVERLINE = [0x203e].pack("U")
     FULLWIDTH_MACRON = [0xffe3].pack("U")
 
+    EM_DASH = [0x2014].pack("U")
+    HORIZONTAL_BAR = [0x2015].pack("U")
+
     module_function
     def deep_apply(obj, &proc)
       case obj
@@ -90,6 +93,8 @@ module Jpmobile
       utf8_str = wavedash_to_fullwidth_tilde(utf8_str)
       # オーバーライン対策(不可逆的)
       utf8_str = overline_to_fullwidth_macron(utf8_str)
+      # ダッシュ対策（不可逆的）
+      utf8_str = emdash_to_horizontal_bar(utf8_str)
 
       if utf8_str.respond_to?(:encode)
         utf8_str.encode(SJIS, :crlf_newline => true)
@@ -208,6 +213,10 @@ module Jpmobile
 
     def fullwidth_macron_to_overline(utf8_str)
       utf8_str.gsub(FULLWIDTH_MACRON, OVERLINE)
+    end
+
+    def emdash_to_horizontal_bar(utf8_str)
+      utf8_str.gsub(EM_DASH, HORIZONTAL_BAR)
     end
 
     def force_encode(str, from, to)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -46,6 +46,10 @@ describe Jpmobile::Util, ".deep_apply" do
     utf8_to_sjis([0x203e].pack("U")).should == sjis("\x81\x50")
   end
 
+  it "U+2014が0x815Cに変換されること" do
+    utf8_to_sjis([0x2014].pack("U")).should == sjis("\x81\x5C")
+  end
+
   it "jis_string_regexpでISO-2022-JPの文字列がマッチすること" do
     jis_string_regexp.match(ascii_8bit(utf8_to_jis("abcしからずんばこじをえずdef"))).should_not be_nil
     jis_to_utf8(jis("\x1b\x24\x42#{$1}\x1b\x28\x42")).should == "しからずんばこじをえず"


### PR DESCRIPTION
お世話になっております。

emダッシュをそのままWindows-31Jに変換出来ないようなのでホリゾンタルバーに置き換えるパッチを書きました。（全角ダッシュにするかホリゾンタルバーにするか迷いましたが…）
