### PR TITLE
マイナス記号変換エラー

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -17,6 +17,9 @@ module Jpmobile
     EM_DASH = [0x2014].pack("U")
     HORIZONTAL_BAR = [0x2015].pack("U")
 
+    MINUS_SIGN = [0x2212].pack("U")
+    FULLWIDTH_HYPHEN_MINUS = [0xFF0D].pack("U")
+
     module_function
     def deep_apply(obj, &proc)
       case obj
@@ -95,6 +98,8 @@ module Jpmobile
       utf8_str = overline_to_fullwidth_macron(utf8_str)
       # ダッシュ対策（不可逆的）
       utf8_str = emdash_to_horizontal_bar(utf8_str)
+      # マイナス対策（不可逆的）
+      utf8_str = minus_sign_to_fullwidth_pyphen_minus(utf8_str)
 
       if utf8_str.respond_to?(:encode)
         utf8_str.encode(SJIS, :crlf_newline => true)
@@ -217,6 +222,14 @@ module Jpmobile
 
     def emdash_to_horizontal_bar(utf8_str)
       utf8_str.gsub(EM_DASH, HORIZONTAL_BAR)
+    end
+
+    def minus_sign_to_fullwidth_pyphen_minus(utf8_str)
+      utf8_str.gsub(MINUS_SIGN, FULLWIDTH_HYPHEN_MINUS)
+    end
+
+    def fullwidth_pyphen_minus_to_minus_sign(utf8_str)
+      utf8_str.gsub(FULLWIDTH_HYPHEN_MINUS, MINUS_SIGN)
     end
 
     def force_encode(str, from, to)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -50,6 +50,10 @@ describe Jpmobile::Util, ".deep_apply" do
     utf8_to_sjis([0x2014].pack("U")).should == sjis("\x81\x5C")
   end
 
+  it "U+2212が0x817Cに変換されること" do
+    utf8_to_sjis([0x2212].pack("U")).should == sjis("\x81\x7C")
+  end
+
   it "jis_string_regexpでISO-2022-JPの文字列がマッチすること" do
     jis_string_regexp.match(ascii_8bit(utf8_to_jis("abcしからずんばこじをえずdef"))).should_not be_nil
     jis_to_utf8(jis("\x1b\x24\x42#{$1}\x1b\x28\x42")).should == "しからずんばこじをえず"


### PR DESCRIPTION
お世話になっております。

マイナス記号を表示する際に変換時にエラーになりました。

```
> [0x2212].pack("U").encode("Windows-31J", :crlf_newline => true)
Encoding::UndefinedConversionError: U+2212 from UTF-8 to Windows-31J
```

[http://www.kab-studio.biz/Programing/JavaA2Z/Word/00000716.html]()  
こちらを参考にして対応してみました。

ご確認いただけますでしょうか？  
よろしくお願いします。
