### PR TITLE
Generate session_id and csrf_token when reset_session. Because form needs

### DIFF
--- a/lib/jpmobile/trans_sid.rb
+++ b/lib/jpmobile/trans_sid.rb
@@ -96,6 +96,11 @@ module Jpmobile::TransSid #:nodoc:
     return result unless apply_trans_sid?
     return result.merge({ session_key => jpmobile_session_id })
   end
+  def reset_session
+    super
+    form_authenticity_token
+    request.session_options[:id] ||= ActiveSupport::SecureRandom.hex(16)
+  end
 
   private
   # session_keyを返す。


### PR DESCRIPTION
Generate session_id and csrf_token when reset_session. Because form needs csrf_token.
