### PR TITLE
rails 3.1をインストールしている環境で、rake test:railsが失敗する

### DIFF
--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -41,7 +41,7 @@ namespace :test do
       # generate rails app
       FileUtils.rm_rf(rails_root)
       FileUtils.mkdir_p(rails_root)
-      `rails new #{rails_root}`
+      `bundle exec rails new #{rails_root}`
     end
 
     # setup jpmobile


### PR DESCRIPTION
rake test:railsでテスト用のプロジェクトを作成してますが、その時にrailsコマンドのみでは
最新のバージョンのプロジェクトを作成するため、3.1.0が入っている環境だと失敗するようです。

対策としては
- `rails _3_0_9 new`のように第2引数にバージョンを指定する方法
- `bundle exec rails new`で`Gemfile`に記載のあるバージョンを使用するようにする
  があるかなと思います。

複数バージョンのrailsでテストを走らせるようにするならば、前者の方法がいいかなと思いますが、
とりあえず、後者のパッチをお送りします。
