### PR TITLE
SJISに変換できない文字を含んだ画面を表示するとエラー

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -102,9 +102,9 @@ module Jpmobile
       utf8_str = minus_sign_to_fullwidth_hyphen_minus(utf8_str)
 
       if utf8_str.respond_to?(:encode)
-        utf8_str.encode(SJIS, :crlf_newline => true)
+        utf8_str.encode(SJIS, :crlf_newline => true,:undef => :replace,:replace => '?')
       else
-        NKF.nkf("-m0 -x -W --oc=cp932", utf8_str).gsub(/\n/, "\r\n")
+        NKF.nkf("-m0 -x -W --oc=cp932 --fb-subchar=63", utf8_str).gsub(/\n/, "\r\n")
       end
     end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -30,6 +30,10 @@ describe Jpmobile::Util, ".deep_apply" do
     deep_apply(string_io) {|obj| obj }.should equal(string_io)
   end
 
+  it "utf8_to_sjis で変換できない文字列が含んでいた場合?に変換される" do
+    utf8_to_sjis("اللغة العربية").should == sjis("????? ???????")
+  end
+
   it "utf8_to_sjis で改行コードが CRLF に変更されること" do
     utf8_to_sjis("UTF8\nTEXT\n").should == sjis("UTF8\r\nTEXT\r\n")
   end


### PR DESCRIPTION
ruby1.9でアラブ文字のようにUTF8では存在するが、Windows-31jに存在しない文字が含まれる
画面を開いた時にエラーになるようです。

ちなみに、1.8では変換できない文字は、削除するようになっていました。

個人的に表示できない文字が含まれている事は、 「?」に変換してもらいたいので、そのように
対応してます。

もし、 元の1.8の挙動に合わせたいと言うことでしたら、修正しますのでご指摘ください。
