### PR TITLE
hankaku_filter :input => trueをしようした場合&nbsp;が変換できない

### DIFF
--- a/lib/jpmobile/filter.rb
+++ b/lib/jpmobile/filter.rb
@@ -64,7 +64,7 @@ module Jpmobile
 
         doc = convert_text_content(doc)
 
-        doc.to_html
+        doc.to_html.gsub("\xc2\xa0","&nbsp;")
       end
     end
 

--- a/test/rails/overrides/app/controllers/filter_controller_base.rb
+++ b/test/rails/overrides/app/controllers/filter_controller_base.rb
@@ -22,4 +22,7 @@ class FilterControllerBase < ApplicationController
   def input_tag
     render :text => '<input hoge="fuu" value="アブラカダブラ" />'
   end
+  def nbsp_char
+    render :text => '<a>アブラ&nbsp;カダブラ</a>'
+  end
 end

--- a/test/rails/overrides/spec/requests/filter_spec.rb
+++ b/test/rails/overrides/spec/requests/filter_spec.rb
@@ -13,6 +13,10 @@ describe "jpmobile integration spec" do
       get "/#{@controller}/input_tag", {}, {"HTTP_USER_AGENT" => @user_agent}
       body.should == send(@conversion_method, '<input hoge="fuu" value="アブラカダブラ">')
     end
+    it "は&nbsp;変換されない" do
+      get "/#{@controller}/nbsp_char", {}, {"HTTP_USER_AGENT" => @user_agent}
+      body.should == send(@conversion_method, '<a>ｱﾌﾞﾗ&nbsp;ｶﾀﾞﾌﾞﾗ</a>')
+    end
   end
 
   shared_examples_for "hankaku_filter :input => false のとき" do
@@ -23,6 +27,10 @@ describe "jpmobile integration spec" do
     it "はinputのvalueの中も半角に変換されること" do
       get "/#{@controller}/input_tag", {}, {"HTTP_USER_AGENT" => @user_agent}
       body.should == send(@conversion_method, '<input hoge="fuu" value="ｱﾌﾞﾗｶﾀﾞﾌﾞﾗ" />')
+    end
+    it "は&nbsp;変換されない" do
+      get "/#{@controller}/nbsp_char", {}, {"HTTP_USER_AGENT" => @user_agent}
+      body.should == send(@conversion_method, '<a>ｱﾌﾞﾗ&nbsp;ｶﾀﾞﾌﾞﾗ</a>')
     end
   end
 


### PR DESCRIPTION
hankaku_filter :input => trueをしようした場合、&nbsp;が?に変換されて表示されてしまいました。

確認した所、Nokogiriのto_htmlは、&nbsp;であった所をU+00A0として出力するようで、
utf8_to_sjisでU+00A0が変換できずに?になってしまったみたいです。

https://github.com/tenderlove/nokogiri/issues/416

hankaku_filter :input => trueの時は、U+00A0を&nbsp;に変換するようにしたバッチを
お送りします。
