### PR TITLE
docomo, AUでPUTリクエスト時に文字コードエラーが出る現象に対応

### DIFF
--- a/lib/jpmobile/rack/params_filter.rb
+++ b/lib/jpmobile/rack/params_filter.rb
@@ -12,7 +12,7 @@ module Jpmobile
         if @mobile = env['rack.jpmobile'] and @mobile.apply_params_filter?
           # パラメータをkey, valueに分解
           # form_params
-          if env['REQUEST_METHOD'] == 'POST'
+          if env['REQUEST_METHOD'] == 'POST' || env['REQUEST_METHOD'] == 'PUT'
             env['rack.input'] = StringIO.new(parse_query(env['rack.input'].read))
           end
 


### PR DESCRIPTION
初めまして rinmu と申します。
いつも jpmobile を使わせてもらっています。

Shift_JIS端末でレコードの生成、更新の処理を行なっていたところ、
create時は問題なく動作し、update時に以下のエラーが発生していました。

ArgumentError (invalid byte sequence in UTF-8)

POSTでは文字コードが正しく解釈されているため、ParamsFilterにPUT時の条件も追加したところ、
update時も文字コードが正しく解釈されるようになりました。

もしよろしければ、本家にマージしてください。

以下の環境で確認を行なっております。
開発環境：ruby 1.9.2 + rails 3.1.0 + mongoid 2.2.1 + jpmobile 2.0.2 
動作確認環境：FireMobileSimulator 1.2.3
