### PR TITLE
jsonデータのpostに対応

### DIFF
--- a/lib/jpmobile/rack/params_filter.rb
+++ b/lib/jpmobile/rack/params_filter.rb
@@ -13,7 +13,9 @@ module Jpmobile
           # パラメータをkey, valueに分解
           # form_params
           if env['REQUEST_METHOD'] == 'POST' || env['REQUEST_METHOD'] == 'PUT'
-            env['rack.input'] = StringIO.new(parse_query(env['rack.input'].read))
+            unless env['CONTENT_TYPE'] =~ /application\/json|application\/xml/
+              env['rack.input'] = StringIO.new(parse_query(env['rack.input'].read))
+            end
           end
 
           # query_params

--- a/spec/rack/jpmobile/params_filter_spec.rb
+++ b/spec/rack/jpmobile/params_filter_spec.rb
@@ -190,4 +190,46 @@ describe Jpmobile::Rack::ParamsFilter do
       end
     end
   end
+
+  context "CONTENT_TYPEに" do
+    context "application/jsonが含まれる場合" do
+      it "inputが変換されないこと" do
+        form_string = '{"index":"1"}'
+
+        res = Rack::MockRequest.env_for(
+          "/",
+          "REQUEST_METHOD" => "POST",
+          "CONTENT_TYPE" => 'application/json',
+          'HTTP_USER_AGENT' => "KDDI-CA32 UP.Browser/6.2.0.7.3.129 (GUI) MMP/2.0",
+          :input => form_string)
+
+        res = Jpmobile::Rack::MobileCarrier.new(Jpmobile::Rack::ParamsFilter.new(UnitApplication.new)).call(res)
+        req = Rack::Request.new(res[1])
+        req.params.size.should == 0
+
+        req.body.read.should  == form_string
+      end
+    end
+  end
+
+  context "CONTENT_TYPEに" do
+    context "application/xmlが含まれる場合" do
+      it "inputが変換されないこと" do
+        form_string = '<?xml version="1.0"?><value><string>hoge</string></value>'
+
+        res = Rack::MockRequest.env_for(
+          "/",
+          "REQUEST_METHOD" => "POST",
+          "CONTENT_TYPE" => 'application/xml',
+          'HTTP_USER_AGENT' => "KDDI-CA32 UP.Browser/6.2.0.7.3.129 (GUI) MMP/2.0",
+          :input => form_string)
+
+        res = Jpmobile::Rack::MobileCarrier.new(Jpmobile::Rack::ParamsFilter.new(UnitApplication.new)).call(res)
+        req = Rack::Request.new(res[1])
+        req.params.size.should == 0
+
+        req.body.read.should  == form_string
+      end
+    end
+  end
 end


### PR DESCRIPTION
お世話になっております
ryooo321と申します。
いつも jpmobile を使わせてもらっています。

XMLHttpRequestでjsonをpostした際にjsonのpost内容がencodeされてしまい、
ActionPackのActionDispatch::ParamsParserで「Error occurred while parsing request parameters.」エラーが発生します。

状況
- rails3.2.11
- jpmobile 3.0.7

クライアントから下記のようなjavascriptコードでjsonをpostした際、

``` javascript
var req = new XMLHttpRequest();
req.open("POST", "/hoge", true);
req.setRequestHeader("Content-Type", "application/json");
params = {"index":"0"}
req.send(JSON.stringify(params));
```

jpmobileのparse_queryで下記のように変換され、

``` ruby
p env['rack.input'].read
 =>'{"index":"0"}'

env['rack.input'] = StringIO.new(parse_query(env['rack.input'].read))

p env['rack.input'].read
 =>'%7B%22index%22%3A%220%22%7D='
```

ActionPackのActionDispatch::ParamsParserでエラーが発生します。

``` ruby
Error occurred while parsing request parameters.
Contents:

MultiJson::DecodeError (795: unexpected token at '%7B%22index%22%3A%220%22%7D=')
```

env['CONTENT_TYPE'] =~ /application\/json|application\/xml/
でない場合のみ、parse_query処理を通過するよう修正しました。

※ 上記エラーにより[better_errors](https://github.com/charliesome/better_errors)が利用できず気づきました。

よろしくお願いいたします
