### PR TITLE
Search all view paths for mobile view templates

### DIFF
--- a/lib/jpmobile/rails.rb
+++ b/lib/jpmobile/rails.rb
@@ -33,7 +33,7 @@ module Jpmobile
         before_filter :register_mobile
 
         self._view_paths = self._view_paths.dup
-        self.view_paths.unshift(Jpmobile::Resolver.new(File.join(Rails.root, "app/views")))
+        self.view_paths.unshift(*self.view_paths.map {|resolver| Jpmobile::Resolver.new(resolver.to_path) })
       end
     end
 


### PR DESCRIPTION
現在 `include Jpmobile::ViewSelector` した場合に Jpmobile のロジックでビューを決定するために使われるパスは Rails.root/app/views のみハードコードされており、エンジンの使用などにより他の箇所にビューテンプレートが置かれている場合、そこは対象になりません。

このパッチでは `include Jpmobile::ViewSelector` したタイミングで見えている `view_paths` をもとに `Jpmobile::Resolver` を複数生成するようにしてみました。

パッチ適用前

```
Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:07:32 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine]
  Rendered test_engine/app/views/test_engine/articles/index.html.erb within layouts/test_engine/application (1.2ms)
Completed 200 OK in 9ms (Views: 8.9ms)

Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:07:38 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine] #<Jpmobile::Mobile::Iphone:0x007fb4db4d3ea0>
  Rendered test_engine/app/views/test_engine/articles/index.html.erb within layouts/test_engine/application (0.3ms)
Completed 200 OK in 4ms (Views: 3.3ms)

Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:07:49 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine] #<Jpmobile::Mobile::Docomo:0x007fb4dac70330>
  Rendered test_engine/app/views/test_engine/articles/index.html.erb within layouts/test_engine/application (0.4ms)
Completed 200 OK in 5ms (Views: 4.6ms)
```

パッチ適用後

```
Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:10:36 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine]
  Rendered test_engine/app/views/test_engine/articles/index.html.erb within layouts/test_engine/application (1.0ms)
Completed 200 OK in 8ms (Views: 7.5ms)


Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:10:43 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine] #<Jpmobile::Mobile::Iphone:0x007f84345dea48>
  Rendered test_engine/app/views/test_engine/articles/index_smart_phone.html.erb within layouts/test_engine/application (0.4ms)
Completed 200 OK in 6ms (Views: 5.6ms)


Started GET "/test_engine/articles/" for 127.0.0.1 at 2013-04-13 12:10:51 +0900
Processing by TestEngine::ArticlesController#index as HTML
[TestEngine] #<Jpmobile::Mobile::Docomo:0x007f84323fe248>
  Rendered test_engine/app/views/test_engine/articles/index_mobile.html.erb within layouts/test_engine/application (0.4ms)
Completed 200 OK in 5ms (Views: 5.1ms)
```
