### PR TITLE
add private

### DIFF
--- a/lib/jpmobile/rails.rb
+++ b/lib/jpmobile/rails.rb
@@ -37,8 +37,6 @@ module Jpmobile
       end
     end
 
-    private
-
     def register_mobile
       if request.mobile
         # register mobile
@@ -49,5 +47,7 @@ module Jpmobile
     def disable_mobile_view!
       self.lookup_context.mobile = []
     end
+
+    private :register_mobile, :disable_mobile_view!
   end
 end


### PR DESCRIPTION
In my application, I'm including Jpmobile::ViewSelector at ApplicationController.
And I'm just refactoring my appliation and using [traceroute gem](https://github.com/amatsuda/traceroute) to pickup unused action.

$rake traceroute

Unused routes:
  rails/info#routes
  rails/info#index
  rails/welcome#index
Unreachable action methods:
  users#show
  users#register_mobile
  users#disable_mobile_view!

I don't want to display #register_mobile,#disable_mobile_view!
please merge this pull request.
