### PR TITLE
use `request.session.id` instead of `request.session_options[:id]`

### DIFF
--- a/lib/jpmobile/trans_sid.rb
+++ b/lib/jpmobile/trans_sid.rb
@@ -130,8 +130,10 @@ module Jpmobile::TransSid #:nodoc:
     key
   end
   # session_idを返す
+  # rack 1.4 (rails3) request.session_options[:id]
+  # rack 1.5 (rails4) request.session.id
   def jpmobile_session_id
-    request.session_options[:id] rescue session.session_id
+    request.session_options[:id] || request.session.id
   end
   # session_idを埋め込むためのhidden fieldを出力する。
   def sid_hidden_field_tag


### PR DESCRIPTION
for rack >= 1.5

`request.session_options` does not contains `:id` key.

see https://github.com/rack/rack/commit/83a270d648205302edbf4534fd3a9055cb121282

remove `rescue session.session_id` because it was written for compatibility 5 years ago.
see https://github.com/jpmobile/jpmobile/commit/41aeb7bc103dfefd7ceac7396c01dac4b882f367
