### PR TITLE
Backport #70 to rails-3-2 branch

### DIFF
--- a/lib/jpmobile/mail.rb
+++ b/lib/jpmobile/mail.rb
@@ -47,12 +47,6 @@ module Mail
     def mobile=(m)
       if @mobile = m
         @charset = m.mail_charset(@charset)
-
-        if self.body
-          self.body.content_type_with_jpmobile = self.content_type
-          self.body.charset = @charset
-          self.body.mobile = m
-        end
       end
     end
 
@@ -65,7 +59,6 @@ module Mail
 
         ready_to_send!
 
-        self.body.charset = @charset
         self.body.mobile  = @mobile
         self.header['Content-Transfer-Encoding'].value = @mobile.content_transfer_encoding(self.header)
         if @mobile.decorated?
@@ -102,6 +95,18 @@ module Mail
       self.body   = body_part
     end
 
+    def init_with_hash_with_jpmobile(hash)
+      if hash[:body_raw]
+        @mobile = hash[:mobile]
+        init_with_string(hash[:body_raw])
+      else
+        init_with_hash_without_jpmobile(hash)
+      end
+    end
+
+    alias_method :init_with_hash_without_jpmobile, :init_with_hash
+    alias_method :init_with_hash, :init_with_hash_with_jpmobile
+
     def init_with_string(string)
       # convert to ASCII-8BIT for ascii incompatible encodings
       s = Jpmobile::Util.ascii_8bit(string)
@@ -115,7 +120,6 @@ module Mail
       process_body_raw_without_jpmobile
 
       if @mobile
-        @body.charset = @charset
         @body.mobile = @mobile
         @body.content_type_with_jpmobile = self.content_type
 
@@ -139,6 +143,11 @@ module Mail
       @raw_source = value.to_crlf
     end
 
+    def separate_parts_with_jpmobile
+      @body.mobile = @mobile
+      separate_parts_without_jpmobile
+    end
+
     alias_method :encoded_without_jpmobile, :encoded
     alias_method :encoded, :encoded_with_jpmobile
 
@@ -147,6 +156,9 @@ module Mail
 
     alias_method :process_body_raw_without_jpmobile, :process_body_raw
     alias_method :process_body_raw, :process_body_raw_with_jpmobile
+
+    alias_method :separate_parts_without_jpmobile, :separate_parts
+    alias_method :separate_parts, :separate_parts_with_jpmobile
 
 # -- docomo
 # multipart/mixed
@@ -248,34 +260,23 @@ module Mail
       # override charset
       if self.header[:content_type]
         content_type_charset = Jpmobile::Util.extract_charset(self.header[:content_type].value)
+        @charset = content_type_charset
         unless content_type_charset.blank?
-          @charset = content_type_charset
           self.header[:content_type].parameters[:charset] = @charset
           @mobile_main_type = self.header[:content_type].main_type
-        end
-
-        if !Jpmobile::Email.convertable?(self.header[:content_type].value) and content_type_charset.blank?
-          @charset = ''
         end
       end
 
       # convert header(s)
       if self.header[:subject]
         subject_charset = Jpmobile::Util.extract_charset(self.header[:subject].value)
-
-        # override subject encoding if @charset is blank
-        @charset = subject_charset if !subject_charset.blank? # and @charset.blank?
         self.header[:subject].charset = subject_charset unless subject_charset.blank?
 
         if @mobile
           subject_value = Encodings.value_decode(self.header[:subject].value)
           subject_converting_encoding = Jpmobile::Util.detect_encoding(subject_value)
           v = @mobile.to_mail_internal(subject_value, subject_converting_encoding)
-          if @charset == subject_charset and @mobile.mail_charset != @charset
-            self.header[:subject].value = Jpmobile::Util.force_encode(v, @charset, Jpmobile::Util::UTF8)
-          else
-            self.header[:subject].value = Jpmobile::Util.force_encode(v, @mobile.mail_charset(@charset), Jpmobile::Util::UTF8)
-          end
+          self.header[:subject].value = Jpmobile::Util.force_encode(v, @mobile.mail_charset(subject_charset), Jpmobile::Util::UTF8)
         end
       end
 
@@ -340,25 +341,18 @@ module Mail
     # convert encoding
     def encoded_with_jpmobile(transfer_encoding = '8bit')
       if @mobile and !multipart?
-        if @mobile.to_mail_body_encoded?(@raw_source)
-          @raw_source
-        elsif Jpmobile::Util.ascii_8bit?(@raw_source)
+        case transfer_encoding
+        when /base64/
           _raw_source = if transfer_encoding == encoding
-                          @raw_source
+                          @raw_source.dup
                         else
-                          enc = Mail::Encodings::get_encoding(get_best_encoding(transfer_encoding))
-                          enc.encode(@raw_source)
+                          get_best_encoding(transfer_encoding).encode(@raw_source)
                         end
-          Jpmobile::Util.force_encode(_raw_source, nil, @charset)
+          Jpmobile::Util.set_encoding(_raw_source, @mobile.mail_charset(@charset))
+        when /quoted-printable/
+          Jpmobile::Util.set_encoding([@mobile.to_mail_body(@raw_source)].pack("M").gsub(/\n/, "\r\n"), @mobile.mail_charset(@charset))
         else
-          case transfer_encoding
-          when /quoted-printable/
-            # [str].pack("M").gsub(/\n/, "\r\n")
-            Jpmobile::Util.force_encode([@mobile.to_mail_body(Jpmobile::Util.force_encode(@raw_source, @charset, Jpmobile::Util::UTF8))].pack("M").gsub(/\n/, "\r\n"), Jpmobile::Util::BINARY, @charset)
-            # @mobile.to_mail_body(Jpmobile::Util.force_encode(@raw_source, @charset, Jpmobile::Util::UTF8))
-          else
-            @mobile.to_mail_body(Jpmobile::Util.force_encode(@raw_source, @charset, Jpmobile::Util::UTF8))
-          end
+          @mobile.to_mail_body(Jpmobile::Util.force_encode(@raw_source, nil, Jpmobile::Util::UTF8))
         end
       else
         encoded_without_jpmobile(transfer_encoding)
@@ -384,9 +378,7 @@ module Mail
 
       if self.multipart? and @mobile
         self.parts.each do |part|
-          part.charset      = @mobile.mail_charset(part.charset)
           part.mobile       = @mobile
-          part.body.charset = part.charset
           part.body.mobile  = @mobile
         end
       end
@@ -400,7 +392,7 @@ module Mail
 
     def preamble_with_jpmobile
       if @mobile
-        Jpmobile::Util.encode(@preamble, @charset)
+        Jpmobile::Util.encode(@preamble, @mobile.mail_charset(@charset))
       else
         preamble_without_jpmobile
       end
@@ -408,7 +400,7 @@ module Mail
 
     def epilogue_with_jpmobile
       if @mobile
-        Jpmobile::Util.encode(@epilogue, @charset)
+        Jpmobile::Util.encode(@epilogue, @mobile.mail_charset(@charset))
       else
         epilogue_without_jpmobile
       end
@@ -416,7 +408,7 @@ module Mail
 
     def crlf_boundary_with_jpmobile
       if @mobile
-        Jpmobile::Util.encode(crlf_boundary_without_jpmobile, @charset)
+        Jpmobile::Util.encode(crlf_boundary_without_jpmobile, @mobile.mail_charset(@charset))
       else
         crlf_boundary_without_jpmobile
       end
@@ -424,7 +416,7 @@ module Mail
 
     def end_boundary_with_jpmobile
       if @mobile
-        Jpmobile::Util.encode(end_boundary_without_jpmobile, @charset)
+        Jpmobile::Util.encode(end_boundary_without_jpmobile, @mobile.mail_charset(@charset))
       else
         end_boundary_without_jpmobile
       end
@@ -453,6 +445,17 @@ module Mail
 
     alias_method :epilogue_without_jpmobile, :epilogue
     alias_method :epilogue, :epilogue_with_jpmobile
+
+    def split!(boundary)
+      self.boundary = boundary
+      parts = raw_source.split(/(?:\A|\r\n)--#{Regexp.escape(boundary)}(?=(?:--)?\s*$)/)
+      # Make the preamble equal to the preamble (if any)
+      self.preamble = parts[0].to_s.strip
+      # Make the epilogue equal to the epilogue (if any)
+      self.epilogue = parts[-1].to_s.sub('--', '').strip
+      parts[1...-1].to_a.each { |part| @parts << Mail::Part.new(:body_raw => part, :mobile => @mobile) }
+      self
+    end
   end
 
   class UnstructuredField

--- a/lib/jpmobile/mailer.rb
+++ b/lib/jpmobile/mailer.rb
@@ -28,7 +28,6 @@ module Jpmobile
         m = super(headers, &block)
 
         m.mobile  = @mobile
-        m.charset = @mobile.mail_charset
 
         # for decorated-mail manipulation
         m.rearrange! if @mobile.decorated?

--- a/spec/unit/email-fixtures/pc-mail-attached-without-subject.eml
+++ b/spec/unit/email-fixtures/pc-mail-attached-without-subject.eml
@@ -1,0 +1,45 @@
+X-Account-Key: account2
+X-UIDL: UID44724-1271041990
+X-Mozilla-Status: 0001
+X-Mozilla-Status2: 10000000
+X-Mozilla-Keys:                                                                                 
+Return-Path: <info@jp.mobile>
+X-Original-To: info+to@jp.mobile
+Delivered-To: info+to@jp.mobile
+Received: from localhost (localhost [127.0.0.1])
+	by mx1.jp.mobile (Postfix) with ESMTP id 916D982D3C
+	for <info+to@jp.mobile>; Mon, 17 Jan 2011 16:43:00 +0900 (JST)
+Received: from mx1.jp.mobile ([127.0.0.1])
+	by localhost (mx1.jp.mobile [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP id 4c+D+lqN6aOJ for <info+to@jp.mobile>;
+	Mon, 17 Jan 2011 16:43:00 +0900 (JST)
+Received: by mx1.jp.mobile (Postfix, from userid 58)
+	id 68BFD82D33; Mon, 17 Jan 2011 16:43:00 +0900 (JST)
+Message-ID: <4D33F300.8050702@jpmobile.jp>
+Date: Mon, 17 Jan 2011 16:42:56 +0900
+From: Shin-ichiro OGAWA <info@jpmobile.jp>
+User-Agent: Mozilla-Thunderbird 2.0.0.24 (X11/20100329)
+MIME-Version: 1.0
+To: info+to@jp.mobile
+Subject:
+Content-Type: multipart/mixed;
+ boundary="------------010605060509040104050402"
+
+This is a multi-part message in MIME format.
+--------------010605060509040104050402
+Content-Type: text/plain; charset=ISO-2022-JP
+Content-Transfer-Encoding: 7bit
+
+本文です
+
+
+--------------010605060509040104050402
+Content-Transfer-Encoding: base64
+Content-Type: image/gif;
+ name="Transparent.gif"
+Content-Disposition: attachment;
+ filename="Transparent.gif"
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--------------010605060509040104050402--
+

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -67,6 +67,21 @@ describe "Jpmobile::Mail#receive" do
       end
     end
 
+    describe "PC mail without subject" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/pc-mail-attached-without-subject.eml")).read)
+      end
+
+      it "body should be parsed correctly" do
+        @mail.body.parts.size.should == 2
+        @mail.body.parts.first.body.to_s.should == "本文です\n\n"
+      end
+
+      it "should encode correctly" do
+        ascii_8bit(@mail.to_s).should match(/GODlhAQABAIAAAAAAAP/)
+      end
+    end
+
     describe "Docomo" do
       before(:each) do
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "../../test/rails/overrides/spec/fixtures/mobile_mailer/docomo-gmail-sjis.eml")).read)
@@ -258,7 +273,7 @@ describe "Jpmobile::Mail#receive" do
 
       it 'should be encoded correctly' do
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-message.eml")).read)
-        @mail.encoded
+        @mail.encoded.should match(Regexp.escape("%[\e$B1`;yL>\e(B]%\e$B$N\e(B%[\e$BJ]8n<TL>\e(B]%"))
       end
     end
 
@@ -271,14 +286,14 @@ describe "Jpmobile::Mail#receive" do
 
       it 'should be encoded correctly' do
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-mail3.eml")).read)
-        @mail.encoded
+        @mail.encoded.should match(/BK\\J82~9T\$J\$7!2#5#1#2J8;z!2/)
       end
     end
 
     it 'should not raise when parsing attached email' do
       lambda {
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/au-attached.eml")).read)
-        @mail.encoded
+        @mail.encoded.should match('/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPQAA')
       }.should_not raise_error
     end
   end


### PR DESCRIPTION
メール受信時に件名なしのメールが正しくパースされない問題修正(#70)のbackportになります。
