### PR TITLE
Apply GetText filter only when GetText is defined

### DIFF
--- a/lib/jpmobile/hook_action_controller.rb
+++ b/lib/jpmobile/hook_action_controller.rb
@@ -4,13 +4,16 @@ require 'jpmobile/lookup_context'
 module ActionController
   class Base
     include Jpmobile::Helpers
-    before_action :gettext_force_ja_for_mobile
-    # gettextが組み込まれている場合、携帯電話からのアクセスをjaロケールに強制する。
-    def gettext_force_ja_for_mobile
-      if Object.const_defined?(:GetText) and request.mobile?
-        begin
-          ::GetText.locale = 'ja'
-        rescue NameError
+
+    if Object.const_defined?(:GetText)
+      before_action :gettext_force_ja_for_mobile
+      # gettextが組み込まれている場合、携帯電話からのアクセスをjaロケールに強制する。
+      def gettext_force_ja_for_mobile
+        if request.mobile?
+          begin
+            ::GetText.locale = 'ja'
+          rescue NameError
+          end
         end
       end
     end


### PR DESCRIPTION
This would reduce the depth of each request call stack for most of recent Rails apps.
