### PR TITLE
iPhone mailerがISO-2022-JPのメールに半角カナを入れてくる問題への対応

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -349,15 +349,25 @@ module Jpmobile
 
     def check_charset(str, charset)
       # use NKF.guess
-      ::Encoding.compatible?(NKF.guess(str), ::Encoding.find(charset))
+      ::Encoding.compatible?(guess_encoding(str), ::Encoding.find(charset))
     end
 
     def correct_encoding(str)
-      if str.encoding != ::Encoding::ASCII_8BIT and NKF.guess(str) != str.encoding
-        str.force_encoding(NKF.guess(str))
+      if guess_encoding(str) != str.encoding
+        str.force_encoding(guess_encoding(str))
       end
 
       str
+    end
+
+    def guess_encoding(str)
+      encoding = NKF.guess(str)
+      # ISO-2022-JPにおいて、JIS X201半角カナエスケープシーケンスが含まれていたらCP50220とみなす
+      if encoding == ::Encoding::ISO2022_JP && str.dup.force_encoding(BINARY).include?("\e(I")
+        ::Encoding::CP50220
+      else
+        encoding
+      end
     end
   end
 end

--- a/spec/unit/email-fixtures/iphone-jis.eml
+++ b/spec/unit/email-fixtures/iphone-jis.eml
@@ -1,0 +1,15 @@
+Delivered-To: info@jpmobile.jp
+From: "jis@i.softbank.jp" <jis@i.softbank.jp>
+Content-Type: text/plain;
+	charset=iso-2022-jp
+X-Mailer: iPhone Mail (12B435)
+Message-Id: <F574F824-7263-44E6-8423-000000000000@i.softbank.jp>
+Date: Fri, 5 Dec 2014 13:14:37 +0900
+To: "info@jpmobile.jp" <info@jpmobile.jp>
+Content-Transfer-Encoding: 7bit
+Mime-Version: 1.0 (1.0)
+X-SB-Service: Virus-Checked
+
+(=ﾟωﾟ)ﾉ
+
+

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -362,6 +362,16 @@ describe "Jpmobile::Mail#receive" do
         expect(@mail.body.to_s).to eq("テスト本文\n\n")
       end
     end
+
+    context "iPhone" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-jis.eml")).read)
+      end
+
+      it "body should be parsed correctly" do
+        expect(@mail.body.to_s).to eq("(=ﾟωﾟ)ﾉ\n\n\n")
+      end
+    end
   end
 
   describe 'bounced mail' do

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -151,4 +151,13 @@ describe Jpmobile::Util do
       expect(correct_encoding(str).encoding).to eq(Encoding::UTF_8)
     end
   end
+
+  describe 'guess_encoding' do
+    it 'guesses encoding correclty' do
+      expect(guess_encoding('テスト')).to eq Encoding::UTF_8
+      expect(guess_encoding("\x83\x65\x83\x58\x83\x67")).to eq Encoding::Shift_JIS
+      expect(guess_encoding("\e\x24\x42\x25\x46\x25\x39\x25\x48\e\x28\x42")).to eq Encoding::ISO2022_JP
+      expect(guess_encoding("\e\x28\x49\x43\x3D\x44\e\x28\x42")).to eq Encoding::CP50220
+    end
+  end
 end


### PR DESCRIPTION
ISO-2022-JPでは本来半角カナは許されないと思うのですが、iPhone mailerは気にせず入れてくるようで受信時にEncoding::InvalidByteSequenceErrorが発生してしまいます。
対策として、文字列中にJIS X201半角カナエスケープシーケンスが含まれている場合はCP50220とみなすことによりエラーを回避し想定通りの変換が行われるようにしました。
どうぞよろしくお願いします。
