### PR TITLE
Backport #83 to rails-3-2 branch

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -429,18 +429,28 @@ module Jpmobile
     def check_charset(str, charset)
       if Object.const_defined?(:Encoding)
         # use NKF.guess
-        ::Encoding.compatible?(NKF.guess(str), ::Encoding.find(charset))
+        ::Encoding.compatible?(guess_encoding(str), ::Encoding.find(charset))
       else
         true
       end
     end
 
     def correct_encoding(str)
-      if str.encoding != ::Encoding::ASCII_8BIT and NKF.guess(str) != str.encoding
-        str.force_encoding(NKF.guess(str))
+      if guess_encoding(str) != str.encoding
+        str.force_encoding(guess_encoding(str))
       end
 
       str
+    end
+
+    def guess_encoding(str)
+      encoding = NKF.guess(str)
+      # ISO-2022-JPにおいて、JIS X201半角カナエスケープシーケンスが含まれていたらCP50220とみなす
+      if encoding == ::Encoding::ISO2022_JP && str.dup.force_encoding(BINARY).include?("\e(I")
+        ::Encoding::CP50220
+      else
+        encoding
+      end
     end
   end
 end

--- a/spec/unit/email-fixtures/iphone-jis.eml
+++ b/spec/unit/email-fixtures/iphone-jis.eml
@@ -1,0 +1,15 @@
+Delivered-To: info@jpmobile.jp
+From: "jis@i.softbank.jp" <jis@i.softbank.jp>
+Content-Type: text/plain;
+	charset=iso-2022-jp
+X-Mailer: iPhone Mail (12B435)
+Message-Id: <F574F824-7263-44E6-8423-000000000000@i.softbank.jp>
+Date: Fri, 5 Dec 2014 13:14:37 +0900
+To: "info@jpmobile.jp" <info@jpmobile.jp>
+Content-Transfer-Encoding: 7bit
+Mime-Version: 1.0 (1.0)
+X-SB-Service: Virus-Checked
+
+(=ﾟωﾟ)ﾉ
+
+

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -362,6 +362,16 @@ describe "Jpmobile::Mail#receive" do
         @mail.body.to_s.should == "テスト本文\n\n"
       end
     end
+
+    context "iPhone" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-jis.eml")).read)
+      end
+
+      it "body should be parsed correctly" do
+        expect(@mail.body.to_s).to eq("(=ﾟωﾟ)ﾉ\n\n\n")
+      end
+    end
   end
 
   describe 'bounced mail' do

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -133,22 +133,33 @@ describe Jpmobile::Util do
     end
   end
 
-  describe 'check_charset' do
-    it 'returns true if compatible' do
-      str = 'ABC'.force_encoding('ASCII-8BIT')
-      check_charset(str, 'UTF-8').should be_true
+  if defined?(Encoding)
+    describe 'check_charset' do
+      it 'returns true if compatible' do
+        str = 'ABC'.force_encoding('ASCII-8BIT')
+        check_charset(str, 'UTF-8').should be_true
+      end
+
+      it 'returns false if incompatible' do
+        str = '再現'.encode('ISO-2022-JP')
+        check_charset(str, 'UTF-8').should be_false
+      end
     end
 
-    it 'returns false if incompatible' do
-      str = '再現'.encode('ISO-2022-JP')
-      check_charset(str, 'UTF-8').should be_false
+    describe 'correct_encoding' do
+      it 'updates encoding correctly' do
+        str = '再現'.force_encoding('ISO-2022-JP')
+        correct_encoding(str).encoding.should == Encoding::UTF_8
+      end
     end
-  end
 
-  describe 'correct_encoding' do
-    it 'updates encoding correctly' do
-      str = '再現'.force_encoding('ISO-2022-JP')
-      correct_encoding(str).encoding.should == Encoding::UTF_8
+    describe 'guess_encoding' do
+      it 'guesses encoding correclty' do
+        expect(guess_encoding('テスト')).to eq Encoding::UTF_8
+        expect(guess_encoding("\x83\x65\x83\x58\x83\x67")).to eq Encoding::Shift_JIS
+        expect(guess_encoding("\e\x24\x42\x25\x46\x25\x39\x25\x48\e\x28\x42")).to eq Encoding::ISO2022_JP
+        expect(guess_encoding("\e\x28\x49\x43\x3D\x44\e\x28\x42")).to eq Encoding::CP50220
+      end
     end
   end
 end


### PR DESCRIPTION
iPhone mailerがISO-2022-JPのメールに半角カナを入れてくる問題への対応(#83)をbackportしました。
大変お手数ですがマージ後3.0系のgemをリリース頂ければ幸いです！
