### PR TITLE
<>でくくられていない日本のメールアドレスの判定に失敗する

### DIFF
--- a/lib/jpmobile/mailer.rb
+++ b/lib/jpmobile/mailer.rb
@@ -2,7 +2,7 @@
 require 'jpmobile/mail'
 require 'jpmobile/lookup_context'
 
-Jpmobile::Email.japanese_mail_address_regexp = Regexp.new(/\.jp[^a-zA-Z\.\-]/)
+Jpmobile::Email.japanese_mail_address_regexp = Regexp.new(/\.jp(?:[^a-zA-Z\.\-]|$)/)
 
 module Jpmobile
   module Mailer

--- a/spec/unit/email_spec.rb
+++ b/spec/unit/email_spec.rb
@@ -55,9 +55,18 @@ describe 'Jpmobile::Email' do
   end
 
   describe "japanese_mail_address_regexp" do
-    it "#detect_from_mail_header should return Jpmobile::Mobile::AbstractMobile when hoge.jp" do
-      Jpmobile::Email.japanese_mail_address_regexp = Regexp.new(/\.jp[^a-zA-Z\.\-]/)
+    before do
+      Jpmobile::Email.japanese_mail_address_regexp = Regexp.new(/\.jp(?:[^a-zA-Z\.\-]|$)/)
+    end
+
+    it "#detect_from_mail_header should return Jpmobile::Mobile::AbstractMobile when the header contains .jp address" do
       expect(Jpmobile::Email.detect_from_mail_header('From: Hoge Fuga <fuga@hoge.jp>')).to eq(Jpmobile::Mobile::AbstractMobile)
+      expect(Jpmobile::Email.detect_from_mail_header('From: fuga@hoge.jp')).to eq(Jpmobile::Mobile::AbstractMobile)
+    end
+
+    it "#detect_from_mail_header should return nil when the header does not contain .jp address" do
+      expect(Jpmobile::Email.detect_from_mail_header('From: Hoge Fuga <fuga@example.com>')).to eq(nil)
+      expect(Jpmobile::Email.detect_from_mail_header('From: fuga@example.com')).to eq(nil)
     end
   end
 


### PR DESCRIPTION
デフォルトのjapanese_mail_address_regexpの正規表現では、メールヘッダーに含まれる日本のメールアドレスが`<>`でくくられていない場合にマッチせず、結果日本語メールとは見なされないようになっています。
この挙動はもともと意図したものではないと思われますので、修正を試みました。
どうぞよろしくお願いします。
