### PR TITLE
iPhone MailによるCP932でエンコードされたメールの受信に対応

### DIFF
--- a/lib/jpmobile/mail.rb
+++ b/lib/jpmobile/mail.rb
@@ -241,10 +241,8 @@ module Mail
 
       # override charset
       if self.header[:content_type]
-        content_type_charset = Jpmobile::Util.extract_charset(self.header[:content_type].value)
-        @charset = content_type_charset
-        unless content_type_charset.blank?
-          self.header[:content_type].parameters[:charset] = @charset
+        @charset = header[:content_type].parameters[:charset] || ''
+        unless @charset.blank?
           @mobile_main_type = self.header[:content_type].main_type
         end
       end

--- a/spec/unit/email-fixtures/iphone-cp932.eml
+++ b/spec/unit/email-fixtures/iphone-cp932.eml
@@ -1,0 +1,13 @@
+Delivered-To: info@jpmobile.jp
+Content-Transfer-Encoding: base64
+Content-Type: text/plain;
+  charset=cp932
+From: "cp932@ezweb.ne.jp" <cp932@ezweb.ne.jp>
+Mime-Version: 1.0 (1.0)
+Subject: =?iso-2022-jp?B?UmU6IBskQiFaGyhCTktTQxskQiFbGyhCdGVzdA==?=
+Message-Id: <3E458B9D-9044-46FE-8A8D-000000000000@ezweb.ne.jp>
+Date: Wed, 10 Dec 2014 17:01:30 +0900
+To: "info@jpmobile.jp" <info@jpmobile.jp>
+X-Mailer: iPhone Mail (12A405)
+
+g2WDWINngsWCt4FCh4o=

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -275,6 +275,12 @@ describe "Jpmobile::Mail#receive" do
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-message.eml")).read)
         expect(@mail.encoded).to match(Regexp.escape("%[\e$B1`;yL>\e(B]%\e$B$N\e(B%[\e$BJ]8n<TL>\e(B]%"))
       end
+
+      it 'should decode cp932-encoded mail correctly' do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-cp932.eml")).read)
+        expect(@mail.subject).to eq 'Re: 【NKSC】test'
+        expect(@mail.body.to_s).to eq 'テストです。㈱'
+      end
     end
 
     context 'From iPad' do


### PR DESCRIPTION
掲題の通りです。
どうぞよろしくお願いします。
