### PR TITLE
NKF.guessが特定のUTF-8文字列についてEncoding:ASCII-8BITを返す問題に対応

### DIFF
--- a/lib/jpmobile/mail.rb
+++ b/lib/jpmobile/mail.rb
@@ -267,10 +267,6 @@ module Mail
           @body_part_jpmobile = Jpmobile::Util.decode(@body_part_jpmobile, self.content_transfer_encoding, @charset)
           self.content_transfer_encoding = @mobile.class::MAIL_CONTENT_TRANSFER_ENCODING
         end
-        unless Jpmobile::Util.check_charset(@body_part_jpmobile, @charset)
-          @body_part_jpmobile = Jpmobile::Util.correct_encoding(@body_part_jpmobile)
-          @charset            = @body_part_jpmobile.encoding.to_s
-        end
         @body_part_jpmobile = @mobile.decode_transfer_encoding(@body_part_jpmobile, @charset)
       end
     end

--- a/lib/jpmobile/mail.rb
+++ b/lib/jpmobile/mail.rb
@@ -36,7 +36,7 @@ module Mail
         header['subject'].mobile = @mobile if header['subject']
         header['from'].mobile    = @mobile if header['from']
         header['to'].mobile      = @mobile if header['to']
-        self.charset             = @mobile.mail_charset
+        self.charset             = @mobile.mail_charset unless multipart?
 
         ready_to_send!
 
@@ -113,7 +113,6 @@ module Mail
 
         if @body.multipart?
           @body.parts.each do |p|
-            p.charset = @mobile.mail_charset(p.charset)
             p.mobile  = @mobile
           end
         end
@@ -130,6 +129,10 @@ module Mail
       separate_parts_without_jpmobile
     end
 
+    def add_charset_with_jpmobile
+      add_charset_without_jpmobile unless multipart? && @mobile
+    end
+
     alias_method :encoded_without_jpmobile, :encoded
     alias_method :encoded, :encoded_with_jpmobile
 
@@ -141,6 +144,9 @@ module Mail
 
     alias_method :separate_parts_without_jpmobile, :separate_parts
     alias_method :separate_parts, :separate_parts_with_jpmobile
+
+    alias_method :add_charset_without_jpmobile, :add_charset
+    alias_method :add_charset, :add_charset_with_jpmobile
 
 # -- docomo
 # multipart/mixed

--- a/spec/unit/email-fixtures/docomo-decomail.eml
+++ b/spec/unit/email-fixtures/docomo-decomail.eml
@@ -1,0 +1,49 @@
+Return-Path: <docomo@docomo.ne.jp>
+Delivered-To: info@jpm-rails.org
+Date: Sun, 06 Feb 2011 17:30:48 +0900 (JST)
+From: docomo@docomo.ne.jp
+To: info@jpm-rails.org
+Subject: =?iso-2022-jp?B?GyRCJUYlOSVIGyhC?=
+Message-ID: <IMTM0i3E149a62f10PSW@docomo.ne.jp>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="RHe5pb6n_0_"
+Content-Transfer-Encoding: 7bit
+
+--RHe5pb6n_0_
+Content-Type: multipart/related; boundary="RHe5pb6n"
+
+--RHe5pb6n
+Content-Type: multipart/alternative; boundary="AzHFwESQ"
+
+--AzHFwESQ
+Content-Type: text/plain; charset="iso-2022-jp"
+Content-Transfer-Encoding: 7bit
+
+ 
+
+テストです 
+--AzHFwESQ
+Content-Type: text/html; charset="iso-2022-jp"
+Content-Transfer-Encoding: quoted-printable
+
+<HTML><HEAD><META http-equiv=3D"Content-Type" content=3D"text/html; charset=
+=3Diso-2022-jp"></HEAD><BODY><DIV align=3D"center"><FONT color=3D"#FF4BFF">=
+=1B$B%F%9%H$G$9=1B(B<IMG src=3D"cid:03@110206.172728@______F03B@docomo.ne.j=
+p"></FONT></DIV></BODY></HTML>
+--AzHFwESQ--
+
+--RHe5pb6n
+Content-Type: image/gif;
+ name="ao_hatena.gif"
+Content-Transfer-Encoding: base64
+Content-ID: <03@110206.172728@______F03B@docomo.ne.jp>
+
+R0lGODlhFAAUAHAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQJMgAEACwAAAAAFAAUAIIjZqoDoO0s
+xf////////8AAAAAAAAAAAAIagAJCBxIsKBBgwASJjyIEIAAAQEiLmRIwOHDixADAGDocMAAjA8l
+Huw4QGPCABk1FrQIcaNAiyIJslT5MiTNgQAixqyY0qVMhTh7UpSpc+LQlzuPvjSqtClFoE55towK
+06fSnEmvMo1KMSAAIfkECTIABAAsAAAAABQAFACCI2aqA6DtLMX/////////AAAAAAAAAAAACGMA
+CQgcSLCgwYMIEypcSACAQ4cMGwIQICCARYgJJ1LcWDEAAIQTBwzgSPGiQY0iPToM0NFjQY0VPwrU
+aJIgAIs1G7aUafPhwIk4eSq8eVHo0JwRfUZcmhHjUppGjyJlqJTpwoAAOw==
+--RHe5pb6n
+--RHe5pb6n_0_--
+

--- a/spec/unit/email-fixtures/iphone-unicode-emoji.eml
+++ b/spec/unit/email-fixtures/iphone-unicode-emoji.eml
@@ -1,0 +1,15 @@
+Delivered-To: info@jpmobile.jp
+Subject: =?utf-8?B?57W15paH5a2X8J+OhQ==?=
+From: "jpmobile@i.softbank.jp" <jpmobile@i.softbank.jp>
+Content-Type: text/plain;
+  charset=utf-8
+X-Mailer: iPhone Mail (12B435)
+Message-Id: <6D20A3C2-DCE3-4A62-95EB-000000000000@i.softbank.jp>
+Date: Wed, 17 Dec 2014 19:13:03 +0900
+To: "info@jpmobile.jp" <info@jpmobile.jp>
+Content-Transfer-Encoding: base64
+Mime-Version: 1.0 (1.0)
+X-SB-Service: Virus-Checked
+
+8J+OhOKdow==
+

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -83,23 +83,48 @@ describe "Jpmobile::Mail#receive" do
     end
 
     describe "Docomo" do
-      before(:each) do
-        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "../../test/rails/overrides/spec/fixtures/mobile_mailer/docomo-gmail-sjis.eml")).read)
+      context "with sjis decomail" do
+        before(:each) do
+          @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "../../test/rails/overrides/spec/fixtures/mobile_mailer/docomo-gmail-sjis.eml")).read)
+        end
+
+        it "subject should be parsed correctly" do
+          expect(@mail.subject).to eq("テスト&#xe6ec;")
+        end
+
+        it "body should be parsed correctly" do
+          expect(@mail.body.parts.size).to eq(1)
+          @mail.body.parts.first.parts.size == 2
+          expect(@mail.body.parts.first.parts.first.body).to match("テストです&#xe72d;")
+          expect(@mail.body.parts.first.parts.last.body.raw_source).to match("テストです&#xe72d;")
+        end
+
+        it "should encode correctly" do
+          expect(@mail.to_s).to match(Regexp.escape("g2WDWINn+ZE"))
+        end
+
+        it "does not cause double-conversion on reparsing" do
+          @reparsed = Mail.new(@mail.to_s)
+          expect(@reparsed.to_s).to match(Regexp.escape("g2WDWINn+ZE"))
+          expect(@reparsed.body.parts.first.parts.first.body).to match("テストです&#xe72d;")
+        end
       end
 
-      it "subject should be parsed correctly" do
-        expect(@mail.subject).to eq("テスト&#xe6ec;")
-      end
+      context "with jis decomail" do
+        before(:each) do
+          @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/docomo-decomail.eml")).read)
+        end
 
-      it "body should be parsed correctly" do
-        expect(@mail.body.parts.size).to eq(1)
-        @mail.body.parts.first.parts.size == 2
-        expect(@mail.body.parts.first.parts.first.body).to match("テストです&#xe72d;")
-        expect(@mail.body.parts.first.parts.last.body.raw_source).to match("テストです&#xe72d;")
-      end
+        it "does not contain charset within multipart Content-Type" do
+          expect(@mail.to_s.scan(/Content-Type:\s+multipart(?:.+;\r\n)*.+[^;]\r\n/)).
+            to satisfy{|matches| matches.all?{|type| !type.include?('charset')}}
+        end
 
-      it "should encode correctly" do
-        expect(@mail.to_s).to match(Regexp.escape("g2WDWINn+ZE"))
+        it "does not cause double-conversion on reparsing" do
+          @reparsed = Mail.new(@mail.to_s)
+          expect(@reparsed.to_s).to match(Regexp.escape("g2WDWINn"))
+          expect(@reparsed.parts.first.parts.first.parts.first.body.decoded).to match("テストです")
+        end
       end
     end
 

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -207,6 +207,20 @@ describe "Jpmobile::Mail#receive" do
         expect(@mail.to_s).to match(sjis_regexp(sjis("\x89\xEF\x8Bc\x82\xAA\x8AJ\x8D\xC3\xF8\xA7")))
       end
     end
+
+    context "JIS mail" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/docomo-jis.eml")).read)
+      end
+
+      it "subject should be parsed correctly" do
+        expect(@mail.subject).to eq("テスト")
+      end
+
+      it "body should be parsed correctly" do
+        expect(@mail.body.to_s).to eq("テスト本文\n\n")
+      end
+    end
   end
 
   describe "Au" do
@@ -338,44 +352,44 @@ describe "Jpmobile::Mail#receive" do
         expect(@mail.to_s).to match(sjis_regexp(utf8_to_sjis("会議が開催") + sjis("\xf7\xdf")))
       end
     end
-  end
 
-  describe "Softbank blank-mail" do
-    before(:each) do
-      @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/softbank-blank.eml")).read)
-    end
-
-    it "subject should be parsed correctly" do
-      expect(@mail.subject).to be_blank
-    end
-
-    it "body should be parsed correctly" do
-      expect(@mail.body.to_s).to be_blank
-    end
-  end
-
-  describe "JIS mail" do
-    context "Docomo" do
+    describe "blank-mail" do
       before(:each) do
-        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/docomo-jis.eml")).read)
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/softbank-blank.eml")).read)
       end
 
       it "subject should be parsed correctly" do
-        expect(@mail.subject).to eq("テスト")
+        expect(@mail.subject).to be_blank
       end
 
       it "body should be parsed correctly" do
-        expect(@mail.body.to_s).to eq("テスト本文\n\n")
+        expect(@mail.body.to_s).to be_blank
       end
     end
+  end
 
-    context "iPhone" do
+  describe "iPhone" do
+    context "JIS mail" do
       before(:each) do
         @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-jis.eml")).read)
       end
 
       it "body should be parsed correctly" do
         expect(@mail.body.to_s).to eq("(=ﾟωﾟ)ﾉ\n\n\n")
+      end
+    end
+
+    context "when the mail contains UTF-8 emojis" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-unicode-emoji.eml")).read)
+      end
+
+      it "subject should be parsed correctly" do
+        expect(@mail.subject).to eq("絵文字\u{1F385}")
+      end
+
+      it "body should be parsed correctly" do
+        expect(@mail.body.to_s).to eq("\u{1F384}\u2763")
       end
     end
   end


### PR DESCRIPTION
UTF-8絵文字と特定の記号を同時に含むメールの受信時にEncoding::InvalidByteSequenceErrorが発生しておりまして、原因を追ったところ`NKF.guess`がエンコーディング判定に失敗しているためと判明しました。
```irb
1.9.3-p545 :002 > NKF.guess "\u{1F384}\u2763"
 => #<Encoding:ASCII-8BIT>
```
この`NKF.guess`して`Jpmobile::Util.correct_encoding`する一連の流れはもともと c556e9aa8a42622e25b8ffd3bcfd55512d1c6d88 で導入されており、その時の[convert_encoding_jpmobile](https://github.com/jpmobile/jpmobile/blob/c556e9aa8a42622e25b8ffd3bcfd55512d1c6d88/lib/jpmobile/mail.rb#L236)の実装では`subject_charset`をメール全体のcharsetとみなしていたため、SubjectとBodyのエンコーディングが異なる場合にうまく対応できず、その回避策としてBodyのエンコーディングをNKF.guessにより判別しそれっぽく処理する実装になっていたものと考えられます。

ただ、#70 のPull Requestによりsubject_charsetとBodyのcharsetを個別に扱えるよう変更が加わっていますので、このfailsafe procedureはもはや不要なはずです。逆に誤検出による問題が出てきてしまうため、この処理を取り除き、#84 でmerge頂いたISO-2022-JP半角カナ問題対策は`Jpmobile::Util.force_encode`に移すよう変更を加えました。

ご確認のほどよろしくお願いします。