### PR TITLE
iPhone mailerがISO-2022-JPのメールにCP50220文字を入れてくる問題への対応

### DIFF
--- a/lib/jpmobile/util.rb
+++ b/lib/jpmobile/util.rb
@@ -252,9 +252,9 @@ module Jpmobile
 
       begin
         s.encode(to)
-      rescue ::Encoding::InvalidByteSequenceError => e
-        # ISO-2022-JPにおいて、JIS X201半角カナエスケープシーケンスが含まれていたらCP50220とみなす
-        if s.encoding == ::Encoding::ISO2022_JP && s.dup.force_encoding(::Encoding::ASCII_8BIT).include?("\e(I")
+      rescue ::Encoding::InvalidByteSequenceError, ::Encoding::UndefinedConversionError => e
+        # iPhone MailがISO-2022-JPに半角カナや①などのCP50220文字を含めてくる問題対策
+        if s.encoding == ::Encoding::ISO2022_JP
           s.force_encoding(::Encoding::CP50220)
           retry
         else

--- a/spec/unit/email-fixtures/iphone-circled-numbers-in-jis.eml
+++ b/spec/unit/email-fixtures/iphone-circled-numbers-in-jis.eml
@@ -1,0 +1,16 @@
+Return-Path: <softbank@i.softbank.jp>
+X-Original-To: info@jpmobile-rails.org
+Delivered-To: info@jpmobile-rails.org
+Subject: =?iso-2022-jp?B?GyRCJUYlOSVILSEbKEI=?=
+From: <softbank@i.softbank.jp>
+X-Mailer: iPhone Mail (12B435)
+Message-Id: <107E70FB-4920-45C4-B0DA-000000000000@i.softbank.jp>
+Date: Mon, 29 Dec 2014 13:02:07 +0900
+To: info@jpmobile-rails.org
+Mime-Version: 1.0 (1.0)
+X-SB-Service: Virus-Checked
+Content-Type: text/plain; charset="iso-2022-jp"
+Content-Transfer-Encoding: 7bit
+
+$B4]?t;z$N%F%9%H$G$9-"|r(B
+

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -417,6 +417,20 @@ describe "Jpmobile::Mail#receive" do
         expect(@mail.body.to_s).to eq("\u{1F384}\u2763")
       end
     end
+
+    context "when the mail contains circled-numbers" do
+      before(:each) do
+        @mail = Mail.new(open(File.join(File.expand_path(File.dirname(__FILE__)), "email-fixtures/iphone-circled-numbers-in-jis.eml")).read)
+      end
+
+      it "subject should be parsed correctly" do
+        expect(@mail.subject).to eq("テスト①")
+      end
+
+      it "body should be parsed correctly" do
+        expect(@mail.body.to_s).to eq("丸数字のテストです②ⅱ\n\n")
+      end
+    end
   end
 
   describe 'bounced mail' do


### PR DESCRIPTION
#83 とも関連するのですが、入れてくるのは半角カナだけではなく丸数字`①`などのCP50220文字をも含むことが判明しました。そのためISO-2022-JPでcharset変換に失敗した際は無条件にCP50220でリトライするようにしています。

また、それに伴いSubjectのcharset変換の流れを見直しました。
現状では絵文字入りのBエンコードされたSubjectを処理する際

1. mail gem側で`Mail::Ruby19.b_value_decode`を呼ぶ
2. 絵文字の処理には機種特有の処理が必要なので、1は失敗。[rescueして](https://github.com/jpmobile/jpmobile/blob/341114dddf12dfc306efb01942ed1246372b2ffd/lib/jpmobile/mail.rb#L14)ASCII-8BITの状態で返す
3. 2で返されたASCII-8BIT文字列を[`convert_encoding_jpmobile`](https://github.com/jpmobile/jpmobile/blob/341114dddf12dfc306efb01942ed1246372b2ffd/lib/jpmobile/mail.rb#L257-268)内で機種特有の処理を`@mobile`インスタンスにまかせつつcharset変換

の流れとなっていますが、この1でわざわざ失敗するのは無意味で、最初から機種特有の知識をもって変換すれば１回で済むと考えました。
そのため`Mail::SubjectField`クラスにて`@mobile`インスタンスを受け取り、Bエンコーディングのデコードを行ってしまう流れに変更してあります。

