### PR TITLE
Add a description about smtpd mock in test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ jpmobile-ipaddressesとjpmobile-terminfoのgemをインストールしていな�
 - `git clone git@github.com:jpmobile/jpmobile-ipaddresses.git`
 - `git clone git@github.com:jpmobile/jpmobile-terminfo.git`
 
-== テストに必要なgemパッケージ
+## テストに必要なgemパッケージ
 テストを実行するためには以下のgemパッケージが必要です。
 * rails (include rack)
 * sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,12 @@ jpmobile-ipaddressesとjpmobile-terminfoのgemをインストールしていな�
 - `git clone git@github.com:jpmobile/jpmobile-ipaddresses.git`
 - `git clone git@github.com:jpmobile/jpmobile-terminfo.git`
 
-## テストに必要なgemパッケージ
+## テスト
+テストにはSMTP通信を行うものも含まれるため、
+[koseki-mocksmtpd](https://github.com/koseki/mocksmtpd)などの、
+smtpdのmockを利用する必要があります。
+
+### 必要なgemパッケージ
 テストを実行するためには以下のgemパッケージが必要です。
 * rails (include rack)
 * sqlite3


### PR DESCRIPTION
`rake test`でテストを実行した際、smtpdが動いていない場合、
以下の様に一部のテストが失敗します。

```
~/Projects/jpmobile
$ rake test                                                                                                                                                                                              master ca7a770
/Users/tomoya/.anyenv/envs/rbenv/versions/2.2.0/bin/ruby -I/Users/tomoya/.anyenv/envs/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-support-3.3.0/lib:/Users/tomoya/.anyenv/envs/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib /Users/tomoya/.anyenv/envs/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/exe/rspec --pattern spec/unit/\*\*/\*_spec.rb
Run options:
  include {:focus=>true}
  exclude {:broken=>true}

All examples were filtered out; ignoring {:focus=>true}
.........................................................................................................................................................................F.....................................................................................................................................................

Failures:

  1) Jpmobile::Mail delivering delivers through SMTP
     Failure/Error: expect {
       expected no Exception, got #<Errno::ECONNREFUSED: Connection refused - connect(2) for "localhost" port 25> with backtrace:
         # ./spec/unit/mail_spec.rb:347:in `block (4 levels) in <top (required)>'
         # ./spec/unit/mail_spec.rb:346:in `block (3 levels) in <top (required)>'
     # ./spec/unit/mail_spec.rb:346:in `block (3 levels) in <top (required)>'

Finished in 1.05 seconds (files took 0.91604 seconds to load)
319 examples, 1 failure

Failed examples:

rspec ./spec/unit/mail_spec.rb:344 # Jpmobile::Mail delivering delivers through SMTP
```

これらのテストを通すにはメールの送信要求を受け付けてなおかつ実際に送信してしまわないようなsmtpdのmockが必要なので、それに関する説明を追記しました。