### PR TITLE
session store に mem_cache_storeを使っていると例外が起こる

### DIFF
--- a/lib/jpmobile/session/mem_cache_store.rb
+++ b/lib/jpmobile/session/mem_cache_store.rb
@@ -1,6 +1,6 @@
 module Rack
   module Session
-    class Memcache
+    class Dalli
       def destroy_session_with_jpmobile(env, session_id, options)
         destroy_session_without_jpmobile(env, session_id, options)
 


### PR DESCRIPTION
Rails4.0から、ActionDispatch::Session::MemCacheStoreはRack::Session::Dalliを継承しています。

https://github.com/rails/rails/blob/4-0-stable/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb#L11

jpmobile/session/mem_cache_store をrequireすると、Rack::Session::Memcacheを読んでしまい、その中の ```require "memcache"```がコールされます。

このため、session storeをmem_cache_storeにしていて、memcache-clientを使用していないRailsアプリでは例外が発生してしまいます。