### PR TITLE
deleted development dependency on rails to avoid latest bundler error

### DIFF
--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency 'rails'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rspec-its'


### PR DESCRIPTION
bundlerの1.10.xだと
```
  gem.add_dependency 'rails', '~> 4.1.0'
````
と
```
  gem.add_development_dependency 'rails'
```
が両方存在するとrailsでjpmobileの読み込みに失敗します。
というわけで、add_development_dependencyを削除しました。