### PR TITLE
Reject files external to app

### DIFF
--- a/lib/jpmobile/resolver.rb
+++ b/lib/jpmobile/resolver.rb
@@ -11,11 +11,12 @@ module Jpmobile
 
     private
 
-    def query(path, details, formats)
+    def query(path, details, formats, outside_app_allowed)
       query = build_query(path, details)
 
       begin
         template_paths = find_template_paths query
+        template_paths = reject_files_external_to_app(template_paths) unless outside_app_allowed
       rescue NoMethodError
         self.class_eval do
           def find_template_paths(query)


### PR DESCRIPTION
This is the fix to work with: http://weblog.rubyonrails.org/2016/1/25/Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released/

I made this patch for rails 4.2.5.1 https://github.com/rails/rails/compare/v4.2.5...v4.2.5.1. This patch needs to be backported.