### PR TITLE
Use dup instead of clone due to compatible with frozen-string-literal

### DIFF
--- a/lib/jpmobile/filter.rb
+++ b/lib/jpmobile/filter.rb
@@ -121,7 +121,7 @@ module Jpmobile
     end
 
     def filter(method, str)
-      str = str.clone
+      str = str.dup
 
       # 一度UTF-8に変換
       before_encoding = nil


### PR DESCRIPTION
Ruby 2.3.0の frozen-string-literal を使っていると、force_encodingでcan't modify frozen Stringのエラーになります。
cloneではなくdupすればfrozenは解除されます。
一応この変更でviewの表示が通ることは確認しました。
