### PR TITLE
frozen-string-literalへの対応

### DIFF
--- a/lib/jpmobile/filter.rb
+++ b/lib/jpmobile/filter.rb
@@ -121,7 +121,7 @@ module Jpmobile
     end
 
     def filter(method, str)
-      str = str.clone
+      str = str.dup
 
       # 一度UTF-8に変換
       before_encoding = nil


### PR DESCRIPTION
Ruby 2.3.0の```frozen-string-literal```を使っていると、```force_encoding```でcan't modify frozen Stringのエラーになります。```clone```ではなく```dup```すればfrozenは解除されます。

このパッチでviewの表示が通ることは確認しました。
