### PR TITLE
Add variant param to pattern for detecting template

### DIFF
--- a/lib/jpmobile/resolver.rb
+++ b/lib/jpmobile/resolver.rb
@@ -1,7 +1,7 @@
 module Jpmobile
   class Resolver < ActionView::FileSystemResolver
     EXTENSIONS = [:locale, :formats, :handlers, :mobile]
-    DEFAULT_PATTERN = ":prefix/:action{_:mobile,}{.:locale,}{.:formats,}{.:handlers,}"
+    DEFAULT_PATTERN = ":prefix/:action{_:mobile,}{.:locale,}{.:formats,}{+:variants,}{.:handlers,}"
 
     def initialize(path, pattern=nil)
       raise ArgumentError, "path already is a Resolver class" if path.is_a?(Resolver)


### PR DESCRIPTION
RailsのActionPack Variants使用時に、 `Jpmobile::Resolver`がテンプレート解決に使われると
正しくViewが選ばれない問題を修正しました。

現在の `Jpmobile::Resolver`の記述では `request.variant`に値を指定しても、
テンプレートパスの生成パターンに`variant`を当てはめる箇所が無いため、
`index.html+hoge.erb` のテンプレートを選ばずに `index.html.erb`が選ばれます。