### PR TITLE
Backport #117 to rails-3-2 branch

### DIFF
--- a/lib/jpmobile/resolver.rb
+++ b/lib/jpmobile/resolver.rb
@@ -32,16 +32,27 @@ module Jpmobile
       File.expand_path(query, @path)
     end
 
-    def query(path, details, formats)
+    def query(path, details, formats, outside_app_allowed)
       query = build_query(path, details)
 
-      # deals with case-insensitive file systems.
-      sanitizer = Hash.new { |h,dir| h[dir] = Dir["#{dir}/*"] }
+      begin
+        template_paths = find_template_paths query
+        template_paths = reject_files_external_to_app(template_paths) unless outside_app_allowed
+      rescue NoMethodError
+        self.class_eval do
+          def find_template_paths(query)
+            # deals with case-insensitive file systems.
+            sanitizer = Hash.new { |h,dir| h[dir] = Dir["#{dir}/*"] }
 
-      template_paths = Dir[query].reject { |filename|
-        File.directory?(filename) ||
-          !sanitizer[File.dirname(filename)].include?(filename)
-      }
+            Dir[query].reject { |filename|
+              File.directory?(filename) ||
+                !sanitizer[File.dirname(filename)].include?(filename)
+            }
+          end
+        end
+
+        retry
+      end
 
       template_paths.map { |template|
         handler, format = extract_handler_and_format(template, formats)


### PR DESCRIPTION
Rails 4.2.5.1 で入った Security Fix のパッチを Rails 3.2 用に backport しました。

* Fix for security update (1a54800c1e545b1ed3482603448e29d98ea077e4)
* Apply reject_files_external_to_app (#117)

可能であればマージ後 Gem をリリースしていただけると助かります :bow: 