### PR TITLE
session.inspect is meaningless.

### DIFF
--- a/lib/jpmobile/trans_sid.rb
+++ b/lib/jpmobile/trans_sid.rb
@@ -116,11 +116,9 @@ module ActionController
 
       case trans_sid_mode
       when :always
-        session.inspect
         return true
       when :mobile
         if request.mobile? and !request.mobile.supports_cookie?
-          session.inspect
           return true
         end
       end


### PR DESCRIPTION
`session.inspect` in Rails3 had read session data.
https://github.com/rails/rails/blob/3-0-stable/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L89

However It doesn't load session data now.
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/request/session.rb#L174