### PR TITLE
Specify license to gemspec

### DIFF
--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
   gem.description   = 'A Rails plugin for mobile devices in Japan'
   gem.summary       = 'Rails plugin for mobile devices in Japan'
   gem.homepage      = 'http://jpmobile-rails.org'
+  gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
https://rubygems.org/gems/jpmobile の LICENSES への記載や、`bundle licenses` での一覧表示などに使われています。適用されているライセンスについて利用者が知る機会が増えるため、次回以降のリリースに向けて指定しておくと良いと考えました。