### PR TITLE
convert_parametersで再帰処理が動いていない

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,9 @@ export MAILTRAP_PASSWORD=YYYYYYYYYYYYYY
 $ bundle exec rake test
 $ bundle exec rubocop
 ```
+
+### railsでのテスト
+
+```
+$ bundle exec rake test:rails
+```

--- a/lib/jpmobile/filter.rb
+++ b/lib/jpmobile/filter.rb
@@ -164,12 +164,28 @@ module Jpmobile
     end
 
     def convert_parameters(params)
-      params.each do |k, v|
-        params[k] = if params[k].respond_to?(:each)
-                      convert_parameters(params[k])
-                    else
-                      to_internal(v)
-                    end
+      if params.respond_to?(:each)
+        case params
+        when Array
+          params.map do |v|
+            if v.respond_to?(:each)
+              convert_parameters(v)
+            else
+              to_internal(v)
+            end
+          end
+        else
+          params.each do |k, v|
+            params[k] =
+              if v.respond_to?(:each)
+                convert_parameters(v)
+              else
+                to_internal(v)
+              end
+          end
+        end
+      else
+        to_internal(params)
       end
     end
   end

--- a/test/rails/overrides/spec/controllers/hankaku_filter_controller_spec.rb
+++ b/test/rails/overrides/spec/controllers/hankaku_filter_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Jpmobile::HankakuFilterController, type: :controller do
+  describe '#index' do
+    let(:params) { { prefecture_ids: ['1', '2'] } }
+
+    it 'should be successful' do
+      request.user_agent = 'DoCoMo/2.0 P05C(c500;TB;W24H16)'
+      get 'index', params: params
+      expect(response).to be_successful
+      expect(request.mobile?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
## 内容

以前は再帰処理を行っていましたが、変更後に再帰処理が正しく動いておりません。

その修正です:bow:

https://github.com/jpmobile/jpmobile/commit/c7217a47b488e004045f252b698676a1f9c189b5#diff-f7d03412694f6e798d8ca433fa776fe9

この時から、うまく動かなくなっていると思います。

```ruby
params = { x : [1, 2] }

この時に再帰処理でparams[k]が`Enumrable`にならない時に落ちます。

```