### PR TITLE
routesが存在しない場合、ActionController::RoutingErrorがraiseされない

### DIFF
--- a/lib/jpmobile/rack/filter.rb
+++ b/lib/jpmobile/rack/filter.rb
@@ -13,7 +13,7 @@ module Jpmobile
 
       status, env, response = @app.call(env)
 
-      if env['Content-Type'].match?(%r{text/html|application/xhtml\+xml})
+      if env['Content-Type']&.match?(%r{text/html|application/xhtml\+xml})
         if mobile && mobile.apply_filter?
           type, charset = env['Content-Type'].split(/;\s*charset=/)
 

--- a/test/rails/overrides/spec/requests/pc_spec.rb
+++ b/test/rails/overrides/spec/requests/pc_spec.rb
@@ -17,4 +17,10 @@ describe 'PCからのアクセスの場合', type: :request do
 
     expect(request.mobile?).to be_falsey
   end
+
+  context 'routesが存在しない場合' do
+    it 'ActionController::RoutingErrorをraiseする' do
+      expect { get '/not_exist', params: {}, env: @headers }.to raise_error ActionController::RoutingError
+    end
+  end
 end


### PR DESCRIPTION
開発ありがとうございます！ 🙏 

## 起きた問題

routesが存在しない場合、 `env['Content-Type']` がnilになるため下記のエラーが発生しました

```
  1) PCからのアクセスの場合 routesが存在しない場合 ActionController::RoutingErrorをraiseする
     Failure/Error: expect { get '/not_exist', params: {}, env: @headers }.to raise_error ActionController::RoutingError
     
       expected ActionController::RoutingError, got #<NoMethodError: undefined method `match?' for nil:NilClass> with backtrace:
         # ./spec/requests/pc_spec.rb:23:in `block (4 levels) in <main>'
         # ./spec/requests/pc_spec.rb:23:in `block (3 levels) in <main>'```
```

おそらく以前だと、 

```ruby
nil =~ %r{text/html|application/xhtml\+xml} # => nil
``` 

となっていたため問題は起きなかったようです。

https://github.com/jpmobile/jpmobile/blob/8960e0c9411a33b8b2409afb78c1442671b39810/lib/jpmobile/rack/filter.rb#L16

## 環境

- Ruby 2.4.4
- Rails 5.2.0


## 対応

以前と同様にnilの場合も対応するようにしました。ご確認お願いします :eyes: