### PR TITLE
Prefer Module#prepend + super over open-classing for extending html_options_for_form

### DIFF
--- a/lib/jpmobile/hook_action_view.rb
+++ b/lib/jpmobile/hook_action_view.rb
@@ -1,11 +1,15 @@
 #:stopdoc:
 # helperを追加
-ActionView::Base.class_eval { include Jpmobile::Helpers }
+# ActionView で trans_sid を有効にする
+ActionView::Base.class_eval do
+  include Jpmobile::Helpers
+
+  delegate :default_url_options, to: :controller unless respond_to?(:default_url_options)
+end
 #:startdoc:
 
 # :stopdoc:
 # accept-charset に charset を変更できるようにする
-# ActionView で trans_sid を有効にする
 module ActionView
   module Helpers
     module FormTagHelper
@@ -24,10 +28,6 @@ module ActionView
         end
       end
     end
-  end
-
-  class Base
-    delegate :default_url_options, to: :controller unless respond_to?(:default_url_options)
   end
 end
 #:startdoc:

--- a/lib/jpmobile/hook_action_view.rb
+++ b/lib/jpmobile/hook_action_view.rb
@@ -10,24 +10,19 @@ end
 
 # :stopdoc:
 # accept-charset に charset を変更できるようにする
-module ActionView
-  module Helpers
-    module FormTagHelper
+module Jpmobile
+  module ActionView
+    module HtmlOptionsWithAcceptCharset
       private
 
       def html_options_for_form(url_for_options, options, *parameters_for_url)
-        accept_charset = (Rails.application.config.jpmobile.form_accept_charset_conversion && request && request.mobile && request.mobile.default_charset) || 'UTF-8'
-
-        options.stringify_keys.tap do |html_options|
-          html_options['enctype'] = 'multipart/form-data' if html_options.delete('multipart')
-          # The following URL is unescaped, this is just a hash of options, and it is the
-          # responsability of the caller to escape all the values.
-          html_options['action']  = url_for(url_for_options, *parameters_for_url)
-          html_options['accept-charset'] = accept_charset
-          html_options['data-remote'] = true if html_options.delete('remote')
+        super.tap do |o|
+          o['accept-charset'] = (Rails.application.config.jpmobile.form_accept_charset_conversion && request && request.mobile && request.mobile.default_charset) || o['accept-charset']
         end
       end
     end
   end
 end
+
+::ActionView::Helpers::FormTagHelper.send :prepend, Jpmobile::ActionView::HtmlOptionsWithAcceptCharset
 #:startdoc:

--- a/lib/jpmobile/rails.rb
+++ b/lib/jpmobile/rails.rb
@@ -2,13 +2,16 @@ ActiveSupport.on_load(:action_controller) do
   require 'jpmobile/docomo_guid'
   require 'jpmobile/filter'
   require 'jpmobile/helpers'
-  require 'jpmobile/hook_action_view'
   require 'jpmobile/trans_sid'
   require 'jpmobile/hook_test_request'
   ActionDispatch::Request.send :prepend, Jpmobile::Encoding
   ActionDispatch::Request.send :include, Jpmobile::RequestWithMobile
   ActionController::Base.send :prepend, Jpmobile::FallbackViewSelector
   ActionController::Base.send :prepend, Jpmobile::TransSidRedirecting
+end
+
+ActiveSupport.on_load(:action_controller) do
+  require 'jpmobile/hook_action_view'
 end
 
 ActiveSupport.on_load(:after_initialize) do


### PR DESCRIPTION
Jpmobile keeps an ancient copy of `html_options_for_form` method but this is quite a dangerous approach for extending an existing method, and in fact Jpmobile has been failing to catch up the upstream changes (our version misses this part https://github.com/rails/rails/blob/7351ccdb880ca4b69d24b2615019ed902652f45e/actionview/lib/action_view/helpers/form_tag_helper.rb#L836-L844 ).

Actually, the Ruby interpreper warns against this method redefinition as follows:
`warning: method redefined; discarding old html_options_for_form`.

This patch fixes these problems by switching the monkey-patch approach to call the framework original verision + inject our own option using Module#prepend.