### PR TITLE
fix NameError

### DIFF
--- a/lib/jpmobile/resolver.rb
+++ b/lib/jpmobile/resolver.rb
@@ -1,5 +1,5 @@
 module Jpmobile
-  class Resolver < ActionView::FileSystemResolver
+  class Resolver < ::ActionView::FileSystemResolver
     EXTENSIONS = [:locale, :formats, :handlers, :mobile].freeze
     DEFAULT_PATTERN = ':prefix/:action{_:mobile,}{.:locale,}{.:formats,}{+:variants,}{.:handlers,}'.freeze
 
@@ -32,7 +32,7 @@ module Jpmobile
                          path.virtual
                        end
 
-        ActionView::Template.new(
+        ::ActionView::Template.new(
           contents,
           File.expand_path(template),
           handler,


### PR DESCRIPTION
`include Jpmobile::ViewSelector` をしているところで、以下のようなエラーが出るようになってしまいました。

```
NameError:
  uninitialized constant Jpmobile::ActionView::FileSystemResolver
```

https://github.com/jpmobile/jpmobile/pull/149 で `module Jpmobile::ActionView` が入ったのでそれが原因かなと思い修正しました。