### PR TITLE
Add scanf to the runtime gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     jpmobile (6.0.0)
       mail (~> 2.7.0)
+      scanf
 
 GEM
   remote: https://rubygems.org/
@@ -179,6 +180,7 @@ GEM
     rubocop-performance (1.4.1)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    scanf (1.0.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'mail', '~> 2.7.0'
+  gem.add_dependency 'scanf'
   gem.add_development_dependency 'capybara-webkit'
   gem.add_development_dependency 'geokit'
   gem.add_development_dependency 'git'


### PR DESCRIPTION
This PR fixes the following error when using Ruby 2.7.0

```console
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]
% cd path/to/jpmobile/jpmobile
% bundle exec rake
/Users/koic/.rbenv/versions/2.7.0/bin/ruby
-I/Users/koic/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.
1/lib:/Users/koic/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rspec-support-3.9.2/lib
/Users/koic/.rbenv/versions/2.
7.0/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.1/exe/rspec --pattern
spec/unit/\*\*/\*_spec.rb

An error occurred while loading ./spec/unit/emoticon_spec.rb. - Did you
mean?
                    rspec ./spec/unit/encoding_spec.rb
                    rspec ./spec/unit/email_spec.rb
                    rspec ./spec/unit/mail_spec.rb

Failure/Error: require 'scanf'

LoadError:
  cannot load such file -- scanf
# ./lib/jpmobile/emoticon.rb:1:in `require'
# ./lib/jpmobile/emoticon.rb:1:in `<top (required)>'
# ./spec/unit/emoticon_spec.rb:3:in `require'
# ./spec/unit/emoticon_spec.rb:3:in `<top (required)>'
Run options:
  include {:focus=>true}
  exclude {:broken=>true}

All examples were filtered out; ignoring {:focus=>true}

Finished in 0.00004 seconds (files took 0.84318 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

Scanf (scanf gem) is no longer bundled gems from Ruby 2.7.0.
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/

This PR add scanf to the runtime gem dependencies.