### PR TITLE
Fixed a bug that access from Instagram in-app browser for Android is falsely detected as via tablet

### DIFF
--- a/lib/jpmobile/mobile/android_tablet.rb
+++ b/lib/jpmobile/mobile/android_tablet.rb
@@ -6,6 +6,6 @@ module Jpmobile::Mobile
     include Jpmobile::Mobile::GoogleEmoticon
 
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = Regexp.union(/(?!Android.+Mobile)Android/, /Android.+SC-01C/)
+    USER_AGENT_REGEXP = Regexp.union(/^(?!.+Mobile).+(?=Android).+$/, /Android.+SC-01C/)
   end
 end

--- a/spec/rack/jpmobile/mobile_by_ua_spec.rb
+++ b/spec/rack/jpmobile/mobile_by_ua_spec.rb
@@ -17,6 +17,7 @@ describe Jpmobile::MobileCarrier do
     [Jpmobile::Mobile::Emobile, 'emobile/1.0.0 (H11T; like Gecko; Wireless) NetFront/3.4'],
     [Jpmobile::Mobile::Iphone, 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; ja-jp) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16'],
     [Jpmobile::Mobile::Android, 'Mozilla/5.0 (Linux; U; Android 1.6; ja-jp; SonyEriccsonSO-01B Build/R1EA018) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'],
+    [Jpmobile::Mobile::Android, 'Mozilla/5.0 (Linux; Android 9; ANE-LX2J Build/HUAWEIANE-LX2J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 Instagram 172.0.0.21.123 Android (28/9; 480dpi; 1080x2060; HUAWEI; ANE-LX2J; HWANE; hi6250; ja_JP; 269790805)'],
     [Jpmobile::Mobile::WindowsPhone, 'Mozilla/4.0 (Compatible; MSIE 6.0; Windows NT 5.1 T-01A_6.5; Windows Phone 6.5)'],
     [Jpmobile::Mobile::BlackBerry, 'BlackBerry9000/4.6.0.224 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/220'],
     [Jpmobile::Mobile::Ipad, 'Mozilla/5.0 (iPad; U; CPU OS 4_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8F191 Safari/6533.18.5'],


### PR DESCRIPTION
Android版Instagramのアプリ内ブラウザからアクセスした場合、デバイスの判定が必ずAndroid Tabletとなってしまう不具合を発見したので修正しました。

Android版Instagramのアプリ内ブラウザではUser Agentを「... Android ... Mobile ... Android ...」といった形で、`Android` という文字列が複数回入る形で設定します。

現状のjpmobileのAndroidTablet判定の正規表現だと、1回だけ `Android ... Mobile` とくるパターンはうまくタブレットでは無いと判定できるのですが、 2回目の `Android` という文字列が来てしまうと、必ずタブレットと判定してしまう状況でした。

そこで「 `Mobile` という文字列は含まず、 `Android` という文字列は含む」という正規表現に修正して、何度 `Android` という文字列が入っても `Mobile` という文字が入っている場合にはタブレットと判定しないように修正しました。