### PR TITLE
Fix `LoadError` when using Rails 6.1

### DIFF
--- a/lib/jpmobile/view_selector.rb
+++ b/lib/jpmobile/view_selector.rb
@@ -1,0 +1,26 @@
+module Jpmobile
+  module ViewSelector
+    def self.included(base)
+      base.class_eval do
+        before_action :register_mobile
+
+        self._view_paths = self._view_paths.dup
+        self.view_paths.unshift(*self.view_paths.map {|resolver| Jpmobile::Resolver.new(resolver.to_path) })
+      end
+    end
+
+    def register_mobile
+      if request.mobile
+        # register mobile
+        self.lookup_context.mobile = request.mobile.variants
+      end
+    end
+
+    def disable_mobile_view!
+      self.lookup_context.mobile = []
+    end
+
+    private :register_mobile, :disable_mobile_view!
+  end
+  Rails::Application::Configuration.include Jpmobile::Configuration::RailsConfiguration
+end


### PR DESCRIPTION
Follow https://github.com/jpmobile/jpmobile/commit/39155df128b70d55ecc477bf35d4bd25429de20f.

This PR fixes the following `LoadError` when using Rails 6.1.

```console
class ApplicationController < ActionController::Base
  include Jpmobile::ViewSelector
end
# => LoadError (cannot load such file -- jpmobile/view_selector)
```

## Rails 6.0

No errors.

```console
% bin/rails c
Running via Spring preloader in process 96658
Loading development environment (Rails 6.0.3.5)
irb(main):001:0> Jpmobile::ViewSelector
=> Jpmobile::ViewSelector
```

## Rails 6.1

`LoadError` occors.

```console
% bin/rails c
Running via Spring preloader in process 91693
Loading development environment (Rails 6.1.3)
irb(main):001:0> Jpmobile::ViewSelector
Traceback (most recent call last):
        1: from (irb):1
LoadError (cannot load such file -- jpmobile/view_selector)
```

Parhaps https://github.com/jpmobile/jpmobile/commit/39155df128b70d55ecc477bf35d4bd25429de20f needed to add `jpmobile/view_selector`. So this PR puts `Jpmobile::ViewSelector` in `jpmobile/view_selector` to prevent `LoadError`.