### PR TITLE
Update jpmobile version from 6.1.2 to 7.0.0 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jpmobile (6.1.2)
+    jpmobile (7.0.0)
       mail (~> 2.7.0)
       rexml
       scanf


### PR DESCRIPTION
## 概要

Gemfile.lockのjpmobileのバージョンを更新します。

## 詳細

### 背景

最新のバージョンで `bundle install` してみたところ、Gemfile.lockに変化がありました。

Gemfile.lockをGitで管理する場合、バージョンを上げるたびに `bundle install` を実行し、Gemfile.lockも同時に更新しないといけないはず。

### 変更内容

現時点のGitHubのmainブランチの最新版で `bundle install` を実行することで、Gemfile.lockを更新しました。

### 直近のバージョン変更時の対応

過去のバージョン変更時にはどう対処していたのか調べてみました。

6.1.2では、バージョン変更とは別のcommitでGemfile.lockを更新している。

- https://github.com/jpmobile/jpmobile/commit/38cb52210a3bff332ac3d6d04614852746c76064
- https://github.com/jpmobile/jpmobile/commit/e1eb34304f15349741558f36f30a453305a6194e

6.1.1では、バージョン変更と同commitでGemfile.lockを更新している。

- https://github.com/jpmobile/jpmobile/commit/a12af34b6ce3428512e17d968e2700fa91e38509

6.1.0では、バージョン変更とは別のcommitでGemfile.lockを更新している。

- https://github.com/jpmobile/jpmobile/commit/2d7599da416f972556cbc2b2e627451f3a7ebc48
- https://github.com/jpmobile/jpmobile/commit/e67ad7569dd1d46190fd084956596c6c899717b1