### PR TITLE
Change RuboCop TargetRubyVersion from 3.0 to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require: rubocop-performance
 inherit_from: './.onkcop-config.yml'
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
   Exclude:
     - 'tmp/**/*'
     - 'bin/*'

--- a/lib/jpmobile/mobile/android.rb
+++ b/lib/jpmobile/mobile/android.rb
@@ -6,6 +6,6 @@ module Jpmobile::Mobile
     include Jpmobile::Mobile::GoogleEmoticon
 
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /Android/
+    USER_AGENT_REGEXP = /Android/.freeze
   end
 end

--- a/lib/jpmobile/mobile/au.rb
+++ b/lib/jpmobile/mobile/au.rb
@@ -6,9 +6,9 @@ module Jpmobile::Mobile
   class Au < AbstractMobile
     # 対応するUser-Agentの正規表現
     # User-Agent文字列中に "UP.Browser" を含むVodafoneの端末があるので注意が必要
-    USER_AGENT_REGEXP = %r{^(?:KDDI|UP.Browser/.+?)-(.+?) }
+    USER_AGENT_REGEXP = %r{^(?:KDDI|UP.Browser/.+?)-(.+?) }.freeze
     # 対応するメールアドレスの正規表現
-    MAIL_ADDRESS_REGEXP = /.+@ezweb\.ne\.jp/
+    MAIL_ADDRESS_REGEXP = /.+@ezweb\.ne\.jp/.freeze
     # 簡易位置情報取得に対応していないデバイスID
     # http://www.au.kddi.com/ezfactory/tec/spec/eznavi.html
     LOCATION_UNSUPPORTED_DEVICE_ID = %w[PT21 TS25 KCTE TST9 KCU1 SYT5 KCTD TST8 TST7 KCTC SYT4 KCTB KCTA TST6 KCT9 TST5 TST4 KCT8 SYT3 KCT7 MIT1 MAT3 KCT6 TST3 KCT5 KCT4 SYT2 MAT1 MAT2 TST2 KCT3 KCT2 KCT1 TST1 SYT1].freeze

--- a/lib/jpmobile/mobile/black_berry.rb
+++ b/lib/jpmobile/mobile/black_berry.rb
@@ -4,6 +4,6 @@ module Jpmobile::Mobile
   # ==BlackBerry
   class BlackBerry < SmartPhone
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /BlackBerry/
+    USER_AGENT_REGEXP = /BlackBerry/.freeze
   end
 end

--- a/lib/jpmobile/mobile/ddipocket.rb
+++ b/lib/jpmobile/mobile/ddipocket.rb
@@ -4,7 +4,7 @@ module Jpmobile::Mobile
   # スーパクラスはWillcom。
   class Ddipocket < Willcom
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = %r{^Mozilla/3.0\(DDIPOCKET}
+    USER_AGENT_REGEXP = %r{^Mozilla/3.0\(DDIPOCKET}.freeze
 
     MAIL_ADDRESS_REGEXP = nil # DdipocketはEmail判定だとWillcomと判定させたい
   end

--- a/lib/jpmobile/mobile/docomo.rb
+++ b/lib/jpmobile/mobile/docomo.rb
@@ -4,9 +4,9 @@ module Jpmobile::Mobile
   # ==DoCoMo携帯電話
   class Docomo < AbstractMobile
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /^DoCoMo/
+    USER_AGENT_REGEXP = /^DoCoMo/.freeze
     # 対応するメールアドレスの正規表現
-    MAIL_ADDRESS_REGEXP = /.+@docomo\.ne\.jp/
+    MAIL_ADDRESS_REGEXP = /.+@docomo\.ne\.jp/.freeze
     # メールのデフォルトのcharset
     MAIL_CHARSET = 'Shift_JIS'.freeze
     # テキスト部分の content-transfer-encoding

--- a/lib/jpmobile/mobile/emobile.rb
+++ b/lib/jpmobile/mobile/emobile.rb
@@ -3,9 +3,9 @@
 module Jpmobile::Mobile
   # ==EMOBILE携帯電話
   class Emobile < AbstractMobile
-    USER_AGENT_REGEXP = %r{^emobile/|^Mozilla/5.0 \(H11T; like Gecko; OpenBrowser\) NetFront/3.4$|^Mozilla/4.0 \(compatible; MSIE 6.0; Windows CE; IEMobile 7.7\) S11HT$}
+    USER_AGENT_REGEXP = %r{^emobile/|^Mozilla/5.0 \(H11T; like Gecko; OpenBrowser\) NetFront/3.4$|^Mozilla/4.0 \(compatible; MSIE 6.0; Windows CE; IEMobile 7.7\) S11HT$}.freeze
     # 対応するメールアドレスの正規表現
-    MAIL_ADDRESS_REGEXP = /.+@emnet\.ne\.jp/
+    MAIL_ADDRESS_REGEXP = /.+@emnet\.ne\.jp/.freeze
     # EMnet対応端末から通知されるユニークなユーザIDを取得する。
     def em_uid
       @request.env['HTTP_X_EM_UID']

--- a/lib/jpmobile/mobile/ipad.rb
+++ b/lib/jpmobile/mobile/ipad.rb
@@ -6,6 +6,6 @@ module Jpmobile::Mobile
     include Jpmobile::Mobile::UnicodeEmoticon
 
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /iPad/
+    USER_AGENT_REGEXP = /iPad/.freeze
   end
 end

--- a/lib/jpmobile/mobile/iphone.rb
+++ b/lib/jpmobile/mobile/iphone.rb
@@ -6,6 +6,6 @@ module Jpmobile::Mobile
     include Jpmobile::Mobile::UnicodeEmoticon
 
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /iPhone/
+    USER_AGENT_REGEXP = /iPhone/.freeze
   end
 end

--- a/lib/jpmobile/mobile/softbank.rb
+++ b/lib/jpmobile/mobile/softbank.rb
@@ -5,9 +5,9 @@ module Jpmobile::Mobile
   # Vodafoneのスーパクラス。
   class Softbank < AbstractMobile
     # 対応するuser-agentの正規表現
-    USER_AGENT_REGEXP = /^(?:SoftBank|Semulator)/
+    USER_AGENT_REGEXP = /^(?:SoftBank|Semulator)/.freeze
     # 対応するメールアドレスの正規表現　ディズニーモバイル対応
-    MAIL_ADDRESS_REGEXP = /.+@(?:softbank\.ne\.jp|disney\.ne\.jp)/
+    MAIL_ADDRESS_REGEXP = /.+@(?:softbank\.ne\.jp|disney\.ne\.jp)/.freeze
     # メールのデフォルトのcharset
     MAIL_CHARSET = 'Shift_JIS'.freeze
     # テキスト部分の content-transfer-encoding

--- a/lib/jpmobile/mobile/vodafone.rb
+++ b/lib/jpmobile/mobile/vodafone.rb
@@ -4,9 +4,9 @@ module Jpmobile::Mobile
   # スーパクラスはSoftbank。
   class Vodafone < Softbank
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /^(Vodafone|Vemulator)/
+    USER_AGENT_REGEXP = /^(Vodafone|Vemulator)/.freeze
     # 対応するメールアドレスの正規表現
-    MAIL_ADDRESS_REGEXP = /.+@[dhtcrknsq]\.vodafone\.ne\.jp/
+    MAIL_ADDRESS_REGEXP = /.+@[dhtcrknsq]\.vodafone\.ne\.jp/.freeze
 
     # cookieに対応しているか？
     def supports_cookie?

--- a/lib/jpmobile/mobile/willcom.rb
+++ b/lib/jpmobile/mobile/willcom.rb
@@ -4,9 +4,9 @@ module Jpmobile::Mobile
   # Ddipocketのスーパクラス。
   class Willcom < AbstractMobile
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = %r{^Mozilla/3.0\(WILLCOM}
+    USER_AGENT_REGEXP = %r{^Mozilla/3.0\(WILLCOM}.freeze
     # 対応するメールアドレスの正規表現
-    MAIL_ADDRESS_REGEXP = /.+@((.+\.)?pdx\.ne\.jp|willcom\.com)/
+    MAIL_ADDRESS_REGEXP = /.+@((.+\.)?pdx\.ne\.jp|willcom\.com)/.freeze
 
     # 位置情報があれば Position のインスタンスを返す。無ければ +nil+ を返す。
     def position

--- a/lib/jpmobile/mobile/windows_phone.rb
+++ b/lib/jpmobile/mobile/windows_phone.rb
@@ -4,6 +4,6 @@ module Jpmobile::Mobile
   # ==WindowsPhone
   class WindowsPhone < SmartPhone
     # 対応するUser-Agentの正規表現
-    USER_AGENT_REGEXP = /Windows Phone/
+    USER_AGENT_REGEXP = /Windows Phone/.freeze
   end
 end


### PR DESCRIPTION
CIがRuboCopのGemspec/RequiredRubyVersion Copで失敗しているのを見つけたので、修正用のPull Requestです。

https://github.com/jpmobile/jpmobile/commit/9edba740b16b0f79ddb5f8b853c0f22cc1420b0f からgemspecでRuby 2.7以上を許可するようになったので、RuboCopのTargetRubyVersionでも2.7を利用する必要が出てきたという話です。

- https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiredrubyversion

Ruby 2.7を対象にするとStyle/MutableConstantに違反するので、併せてこれも `rubocop -A` で修正しています。