### PR TITLE
Change mobile template priority

### DIFF
--- a/lib/jpmobile/template_details.rb
+++ b/lib/jpmobile/template_details.rb
@@ -19,8 +19,8 @@ module Jpmobile
         requested.formats_idx[@format],
         requested.locale_idx[@locale],
         requested.variants_idx[@variant],
-        requested.handlers_idx[@handler],
         requested.mobile_idx[@mobile],
+        requested.handlers_idx[@handler],
       ]
     end
 


### PR DESCRIPTION
To resolve https://github.com/jpmobile/jpmobile/issues/198.

テンプレート候補を優先度順に並び替える際、handler (erbやhaml等) より mobile (smart_phone等) の一致を優先するように変更します。