### PR TITLE
Improve some URLs in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,7 @@ Metrics/ModuleLength:
 Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
+    - 'jpmobile.gemspec'
     - 'lib/jpmobile/emoticon.rb'
     - 'lib/tasks/jpmobile_tasks.rake'
     - 'test/rails/overrides/config/routes.rb'

--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ['rust.stnard@gmail.com']
   gem.description   = 'A Rails plugin for mobile devices in Japan'
   gem.summary       = 'Rails plugin for mobile devices in Japan'
-  gem.homepage      = 'http://jpmobile-rails.org'
+  gem.homepage      = 'https://jpmobile-rails.org'
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)

--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://jpmobile-rails.org'
   gem.license       = 'MIT'
 
+  gem.metadata['source_code_uri'] = 'https://github.com/jpmobile/jpmobile'
+
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|system)/})
   gem.require_paths = ['lib']

--- a/jpmobile.gemspec
+++ b/jpmobile.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.metadata['source_code_uri'] = 'https://github.com/jpmobile/jpmobile'
+  gem.metadata['documentation_uri'] = gem.metadata['source_code_uri']
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|system)/})


### PR DESCRIPTION
gemspecのメタデータを幾らか改善したいのですが、どうでしょう？

- ホームページのURLをHTTPからHTTPSに変更しました
    - 余計なリダイレクトを省けます
- ソースコードへのリンクを追加しました
    - gemspecからソースコードの情報が得られなかったため
    - https://rubygems.org/gems/jpmobile は多分サイト上で編集したのでリンクが表示されている
    - 2018年末に編集機能は廃止されたので、もはや編集はできない
        - つまり書くならgemspecに書いた方がいい
- ~~変更履歴へのリンクを追加しました~~
    - jpmobileはCHANGELOG.mdを持っていないことが発覚したのでやめました

人間向けのインターフェースだと、https://rubygems.org/gems/jpmobile のこのへんに影響があります:

![image](https://user-images.githubusercontent.com/111689/175791956-cbe2a422-8e57-4167-8a66-274f53f80f49.png)

GitHubのリポジトリに登録されているウェブサイトもHTTPになってたので、これは手作業で変える必要があるかも。

![image](https://user-images.githubusercontent.com/111689/175792336-4f82e019-081b-46c6-bce6-62ccf77033ef.png)