### PR TITLE
Improve branch coverage of Util and mobile carrier classes

### DIFF
--- a/spec/unit/mobile/abstract_mobile_spec.rb
+++ b/spec/unit/mobile/abstract_mobile_spec.rb
@@ -1,0 +1,56 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::AbstractMobile do
+  def build(request = nil)
+    described_class.new({}, request)
+  end
+
+  describe '#mail_variants' do
+    it '2回目以降は memoize した同一オブジェクトを返すこと' do
+      mobile = build
+      first = mobile.mail_variants
+      expect(mobile.mail_variants).to equal(first)
+    end
+  end
+
+  describe '#content_transfer_encoding' do
+    it 'text/plain で 7bit ならその値を返すこと' do
+      headers = { 'Content-Type' => 'text/plain', 'Content-Transfer-Encoding' => '7bit' }
+      expect(build.content_transfer_encoding(headers)).to eq('7bit')
+    end
+
+    it 'text/html かつ decorated なら quoted-printable を返すこと' do
+      mobile = build
+      mobile.decorated = true
+      expect(mobile.content_transfer_encoding('Content-Type' => 'text/html')).to eq('quoted-printable')
+    end
+
+    it 'text/html かつ非 decorated で 7bit ならその値を返すこと' do
+      mobile = build
+      mobile.decorated = false
+      headers = { 'Content-Type' => 'text/html', 'Content-Transfer-Encoding' => '7bit' }
+      expect(mobile.content_transfer_encoding(headers)).to eq('7bit')
+    end
+  end
+
+  describe '#utf8_to_mail_encode' do
+    it 'mail_charset が ISO-2022-JP/Shift_JIS 以外ならそのまま返すこと' do
+      mobile = build
+      allow(mobile).to receive(:mail_charset).and_return('UTF-8')
+      expect(mobile.utf8_to_mail_encode('テスト')).to eq('テスト')
+    end
+  end
+
+  describe '.valid_ip?' do
+    it 'IP 帯域定義が無いキャリアでは false を返すこと' do
+      expect(described_class.valid_ip?('1.2.3.4')).to be_falsey
+    end
+  end
+
+  describe '#params' do
+    it 'request が parameters を持つ場合は parameters を参照すること' do
+      mobile = build(double('request', parameters: { 'a' => '1' }))
+      expect(mobile.send(:params)).to eq('a' => '1')
+    end
+  end
+end

--- a/spec/unit/mobile/android_spec.rb
+++ b/spec/unit/mobile/android_spec.rb
@@ -1,0 +1,9 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::Android do
+  describe '.check_client_hints' do
+    it 'Client Hints が Android を示さないときは nil を返すこと' do
+      expect(described_class.check_client_hints({})).to be_nil
+    end
+  end
+end

--- a/spec/unit/mobile/au_spec.rb
+++ b/spec/unit/mobile/au_spec.rb
@@ -1,0 +1,52 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::Au do
+  def build(params: {}, env: {})
+    request = double('request', params: params, env: env)
+    described_class.new(env, request)
+  end
+
+  describe '#position' do
+    it 'unit=dms で緯度が dms 形式でないと例外になること' do
+      au = build(params: { 'lat' => 'invalid', 'lon' => '141.20.50.75', 'unit' => 'dms' })
+      expect { au.position }.to raise_error('Invalid dms form')
+    end
+
+    it 'unit=dms で経度が dms 形式でないと例外になること' do
+      au = build(params: { 'lat' => '43.04.55.00', 'lon' => 'invalid', 'unit' => 'dms' })
+      expect { au.position }.to raise_error('Invalid dms form')
+    end
+
+    it 'unit が 1/0/dms のいずれでもないときは nil を返すこと' do
+      au = build(params: { 'lat' => '43.04.55.00', 'lon' => '141.20.50.75', 'unit' => '99' })
+      expect(au.position).to be_nil
+    end
+  end
+
+  describe '#device_id' do
+    it 'User-Agent が Au の正規表現に一致しないときは nil を返すこと' do
+      au = build(env: { 'HTTP_USER_AGENT' => 'Mozilla/5.0' })
+      expect(au.device_id).to be_nil
+    end
+  end
+
+  describe '#supports_cookie?' do
+    it 'scheme を持たない request では protocol を見て判定すること' do
+      request = double('legacy request', params: {}, protocol: 'http://example.jp')
+      au = described_class.new({}, request)
+      expect(au.supports_cookie?).to be_truthy
+    end
+  end
+
+  describe '#to_external' do
+    it 'content_type が変換対象外のときは Shift_JIS 変換せず charset を維持すること' do
+      _str, charset = build.to_external('あ', 'application/json', 'UTF-8')
+      expect(charset).to eq('UTF-8')
+    end
+
+    it '空文字のときは charset を default に上書きしないこと' do
+      _str, charset = build.to_external('', nil, 'UTF-8')
+      expect(charset).to eq('UTF-8')
+    end
+  end
+end

--- a/spec/unit/mobile/docomo_spec.rb
+++ b/spec/unit/mobile/docomo_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::Docomo do
+  def build(params: {}, env: {})
+    described_class.new(env, double('request', params: params, env: env))
+  end
+
+  describe '#position' do
+    it '緯度が DoCoMo の dms 形式でないと例外になること' do
+      docomo = build(params: { 'lat' => '35.40.30.5', 'lon' => '+139.40.30.5', 'geo' => 'wgs84' })
+      expect { docomo.position }.to raise_error('Unsuppoted')
+    end
+
+    it '経度が DoCoMo の dms 形式でないと例外になること' do
+      docomo = build(params: { 'lat' => '+35.40.30.5', 'lon' => '139.40.30.5', 'geo' => 'wgs84' })
+      expect { docomo.position }.to raise_error('Unsuppoted')
+    end
+  end
+
+  describe '#to_external' do
+    it 'content_type が変換対象外なら Shift_JIS 変換せず charset を維持すること' do
+      _str, charset = build.to_external('あ', 'application/json', 'UTF-8')
+      expect(charset).to eq('UTF-8')
+    end
+
+    it '空文字なら charset を default に上書きしないこと' do
+      _str, charset = build.to_external('', nil, 'UTF-8')
+      expect(charset).to eq('UTF-8')
+    end
+  end
+
+  describe '#imode_browser_version' do
+    it 'DoCoMo/1.0/・DoCoMo/2.0 以外（DoCoMo/3.0 等）は 2.0 を返すこと' do
+      docomo = build(env: { 'HTTP_USER_AGENT' => 'DoCoMo/3.0 N01A(c500;TB;W24H16)' })
+      expect(docomo.imode_browser_version).to eq('2.0')
+    end
+  end
+
+  describe '#model_name' do
+    it 'DoCoMo のモデル名パターンに一致しない UA では nil を返すこと' do
+      docomo = build(env: { 'HTTP_USER_AGENT' => 'Mozilla/5.0' })
+      expect(docomo.model_name).to be_nil
+    end
+  end
+end

--- a/spec/unit/mobile/iphone_spec.rb
+++ b/spec/unit/mobile/iphone_spec.rb
@@ -30,4 +30,15 @@ describe Jpmobile::Mobile::Iphone do
       expect(mobile.unicode_emoticon?).to be_truthy
     end
   end
+
+  describe '#to_internal' do
+    it 'iOS5+ では Unicode 6.0 絵文字として SoftBank 絵文字へ変換すること' do
+      request = double('request')
+      allow(request).to receive(:user_agent) { 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3' }
+
+      mobile = Jpmobile::Mobile::Iphone.new({}, request)
+      # U+2600(晴れ) は SoftBank 絵文字 U+F04A に変換される
+      expect(mobile.to_internal([0x2600].pack('U'))).to eq([0xf04a].pack('U'))
+    end
+  end
 end

--- a/spec/unit/mobile/softbank_spec.rb
+++ b/spec/unit/mobile/softbank_spec.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::Softbank do
+  def build(params: {}, env: {})
+    described_class.new(env, double('request', params: params, env: env))
+  end
+
+  describe '#position' do
+    it 'geo が wgs84 でないと例外になること' do
+      sb = build(params: { 'pos' => 'N35.40.30.5E139.40.30.5', 'geo' => 'tokyo' })
+      expect { sb.position }.to raise_error('Unsupported datum')
+    end
+
+    it '南緯・西経（S/W）の座標を負の値として扱うこと' do
+      sb = build(params: { 'pos' => 'S35.40.30.5W139.40.30.5', 'geo' => 'wgs84' })
+      expect(sb.position.lat).to be < 0
+      expect(sb.position.lon).to be < 0
+    end
+  end
+end

--- a/spec/unit/mobile/willcom_spec.rb
+++ b/spec/unit/mobile/willcom_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+
+describe Jpmobile::Mobile::Willcom do
+  def build(params: {})
+    described_class.new({}, double('request', params: params))
+  end
+
+  describe '#position' do
+    it 'pos が Willcom の形式でないと例外になること' do
+      willcom = build(params: { 'pos' => 'invalid' })
+      expect { willcom.position }.to raise_error('unsupported format')
+    end
+  end
+end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -91,6 +91,15 @@ describe Jpmobile::Util do
     it 'frozenでも通過すること' do
       expect { force_encode('漢字'.encode('ISO-2022-JP').freeze, 'iso-2022-jp', 'UTF-8') }.not_to raise_error
     end
+
+    it 'to に shift_jis を指定すると Windows-31J へ変換すること' do
+      expect(force_encode('あ', 'UTF-8', 'shift_jis').encoding).to eq(Encoding::Windows_31J)
+    end
+
+    it 'すでに変換先エンコーディングの文字列はそのまま（同一オブジェクトで）返すこと' do
+      str = 'a'.force_encoding('CP932')
+      expect(force_encode(str, nil, 'CP932')).to equal(str)
+    end
   end
 
   describe '#fold_text' do
@@ -158,6 +167,11 @@ describe Jpmobile::Util do
     it 'frozenでも通過すること' do
       expect { jis_win('漢字'.freeze) }.not_to raise_error
     end
+
+    it 'すでにJISエンコードの文字列は再エンコードせずそのまま返すこと' do
+      jis_str = '漢字'.encode('ISO-2022-JP')
+      expect(jis_win(jis_str)).to equal(jis_str)
+    end
   end
 
   describe '#ascii_8bit' do
@@ -204,6 +218,38 @@ describe Jpmobile::Util do
       )
       expect(hash[0x3013]).to eq([0x1F1E8, 0x1F1F3])
       expect(hash[0xE6FB]).to eq(0x1F526)
+    end
+  end
+
+  describe '#deep_convert' do
+    it 'Symbolを変換し再びSymbolで返すこと' do
+      expect(deep_convert(:foo, &:upcase)).to eq(:FOO)
+    end
+
+    it 'to_paramを持たないStringはそのままyieldされること' do
+      expect('foo'.respond_to?(:to_param)).to be_falsey
+      expect(deep_convert('foo', &:upcase)).to eq('FOO')
+    end
+
+    it 'Hash/Array/Symbol/String以外（Integer等）はyieldせずそのまま返すこと' do
+      expect(deep_convert(42) {|_| raise 'should not be called' }).to eq(42)
+    end
+  end
+
+  describe '#encode' do
+    it 'charsetがutf-8のときはそのまま返すこと' do
+      str = 'あ'
+      expect(encode(str, 'utf-8')).to eq(str)
+    end
+
+    it '対応しない文字コードを指定するとnilになること（iso-2022-jp/shift_jis/utf-8のみ対応）' do
+      expect(encode('あ', 'euc-jp')).to be_nil
+    end
+  end
+
+  describe '#decode' do
+    it 'quoted-printable/base64以外のencodingは本文をそのまま扱うこと' do
+      expect(decode('plain text', '7bit', 'UTF-8')).to eq('plain text')
     end
   end
 end


### PR DESCRIPTION
## 概要

`enable_coverage :branch` で計測しているブランチカバレッジを、**テストコードの追加のみ**（本体/設定は無改変）で引き上げる。今回は `Jpmobile::Util` と `mobile/*` 端末クラス群を対象とした。

ブランチカバレッジ: **71.6% → 77.9%**（396 → 431/553）

## 追加したテスト

- **util.rb**: `deep_convert`（Symbol / to_param を持たない String / 非コレクション型）、`jis_win`（JIS 済み入力）、`encode`（utf-8 / 非対応 charset）、`force_encode`（shift_jis 指定エイリアス / 変換先一致）、`decode`（quoted-printable・base64 以外）
- **mobile 端末クラス**（request double で直接インスタンス化して駆動）:
  - Au: position の dms バリデーション例外 / 非対応 unit、device_id の UA 不一致、supports_cookie? の legacy protocol、to_external の非 HTML / 空文字
  - Docomo: position の dms 例外、to_external、imode_browser_version フォールバック、model_name 非該当 UA
  - Softbank: position の datum チェック・南緯/西経（負値）
  - Willcom: position フォーマット例外
  - Android: check_client_hints の否定系
  - Iphone: to_internal が iOS5+ で Unicode 絵文字→SoftBank 絵文字変換
  - AbstractMobile: mail_variants の memoize、content_transfer_encoding（text/plain・decorated/非 decorated の text/html）、utf8_to_mail_encode のフォールスルー、valid_ip? の IP 帯域なし、params の #parameters 経由

各テストは分岐の「実行」だけでなく、その分岐が表す**挙動をアサート**している。

## 補足: テストのみでは到達できない分岐

調査の結果、テストコード追加だけでは到達できない（=本コミットでは対象外とした）分岐が存在することが分かった:

- `mobile/abstract_mobile.rb` L270 `next if carrier_class == self` — `Jpmobile::Mobile.carriers` に `AbstractMobile` は含まれず、かつクラスロード時に1回だけ実行されるため再現不可
- `mobile/docomo.rb` L32 `raise 'Unsuppoted datum' unless geo.casecmp('wgs84')` — `casecmp` は一致時に `0`（真値）を返すため、String 引数では決して raise しない（`casecmp?` もしくは `!= 0` が意図と思われる潜在バグ）
- `emoticon.rb` L45/L54（docomo/au の unmapped 分岐）— 該当正規表現が変換テーブルの全コード列挙から自動生成されており、一致する入力は必ずテーブルに存在するため `unicode` が nil にならない

emoticon.rb / mail.rb / Rails 統合系の残りは別 PR で継続予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)