### PR TITLE
Fix the Rails run being left out of the coverage report

### DIFF
--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -175,6 +175,8 @@ task :coverage do
         end
       rescue JSON::ParserError => e
         problems << "result is invalid JSON (#{e.message})"
+      rescue SystemCallError => e
+        problems << "result could not be read (#{e.class}: #{e.message})"
       end
     end
 

--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -161,17 +161,38 @@ task :coverage do
 
     rails_result = File.join(Dir.pwd, 'coverage', 'rails', '.resultset.json')
     rails_mtime = File.mtime(rails_result) if File.exist?(rails_result)
-    rails_data = JSON.parse(File.read(rails_result)) if rails_mtime
-    rails_commands = rails_data&.keys
-    rails_timestamp = rails_data&.dig('rails', 'timestamp')
-    rails_recorded_at = Time.at(rails_timestamp) if rails_timestamp.is_a?(Numeric)
-
     problems = []
     problems << 'result is missing' unless rails_mtime
     problems << 'result is stale' if rails_mtime && rails_mtime < coverage_started_at
-    problems << 'command "rails" is missing' if rails_commands && !rails_commands.include?('rails')
-    problems << 'command "rails" timestamp is missing' if rails_commands&.include?('rails') && !rails_recorded_at
-    problems << 'command "rails" is stale' if rails_recorded_at && rails_recorded_at < coverage_started_at
+
+    if rails_mtime
+      begin
+        parsed = JSON.parse(File.read(rails_result))
+        if parsed.is_a?(Hash)
+          rails_data = parsed
+        else
+          problems << "result is #{parsed.class}, expected a JSON object"
+        end
+      rescue JSON::ParserError => e
+        problems << "result is invalid JSON (#{e.message})"
+      end
+    end
+
+    rails_commands = rails_data&.keys
+    if rails_data
+      rails_command = rails_data['rails']
+      if !rails_data.has_key?('rails')
+        problems << 'command "rails" is missing'
+      elsif !rails_command.is_a?(Hash)
+        problems << "command \"rails\" is #{rails_command.class}, expected a JSON object"
+      else
+        rails_timestamp = rails_command['timestamp']
+        rails_recorded_at = Time.at(rails_timestamp) if rails_timestamp.is_a?(Numeric)
+        problems << 'command "rails" timestamp is missing' unless rails_recorded_at
+        problems << 'command "rails" is stale' if rails_recorded_at && rails_recorded_at < coverage_started_at
+        problems << 'command "rails" coverage is not a JSON object' unless rails_command['coverage'].is_a?(Hash)
+      end
+    end
 
     unless problems.empty?
       coverage_error = RuntimeError.new(

--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -146,12 +146,20 @@ end
 desc 'Run the full test suite with coverage and emit a merged report'
 task :coverage do
   ENV['COVERAGE'] = '1'
+  coverage_started_at = Time.now
 
   test_error = nil
   begin
     Rake::Task['test'].invoke
   rescue SystemExit, StandardError => e
     test_error = e
+  end
+
+  if test_error.nil?
+    rails_result = File.join(Dir.pwd, 'coverage', 'rails', '.resultset.json')
+    unless File.exist?(rails_result) && File.mtime(rails_result) >= coverage_started_at
+      raise 'Rails coverage was not collected by this run; an existing result may be stale'
+    end
   end
 
   report_error = nil

--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -102,6 +102,7 @@ namespace :test do
 
     # run tests in rails
     gem_root = Dir.pwd
+    coverage = ENV.fetch('COVERAGE', nil)
     Dir.chdir(rails_root) do
       Bundler.with_unbundled_env do
         original_env = ENV.to_hash
@@ -111,11 +112,16 @@ namespace :test do
         system 'bundle install'
         system 'bin/rails db:migrate RAILS_ENV=test' unless skip
 
-        if ENV['COVERAGE']
+        if coverage
           # bin/rails loads jpmobile before RSpec can require spec_helper, and Coverage cannot recover earlier loads.
           rubyopt = [ENV.fetch('RUBYOPT', nil), '-r./coverage.rb'].compact.join(' ')
           system(
-            { 'JPMOBILE_GEM_ROOT' => gem_root, 'RUBYOPT' => rubyopt },
+            {
+              'COVERAGE' => coverage,
+              'JPMOBILE_COVERAGE_LAUNCHER' => '1',
+              'JPMOBILE_GEM_ROOT' => gem_root,
+              'RUBYOPT' => rubyopt,
+            },
             'bin/rails spec',
             exception: true,
           )

--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -155,10 +155,31 @@ task :coverage do
     test_error = e
   end
 
-  if test_error.nil?
+  coverage_error = nil
+  unless test_error
+    require 'json'
+
     rails_result = File.join(Dir.pwd, 'coverage', 'rails', '.resultset.json')
-    unless File.exist?(rails_result) && File.mtime(rails_result) >= coverage_started_at
-      raise 'Rails coverage was not collected by this run; an existing result may be stale'
+    rails_mtime = File.mtime(rails_result) if File.exist?(rails_result)
+    rails_data = JSON.parse(File.read(rails_result)) if rails_mtime
+    rails_commands = rails_data&.keys
+    rails_timestamp = rails_data&.dig('rails', 'timestamp')
+    rails_recorded_at = Time.at(rails_timestamp) if rails_timestamp.is_a?(Numeric)
+
+    problems = []
+    problems << 'result is missing' unless rails_mtime
+    problems << 'result is stale' if rails_mtime && rails_mtime < coverage_started_at
+    problems << 'command "rails" is missing' if rails_commands && !rails_commands.include?('rails')
+    problems << 'command "rails" timestamp is missing' if rails_commands&.include?('rails') && !rails_recorded_at
+    problems << 'command "rails" is stale' if rails_recorded_at && rails_recorded_at < coverage_started_at
+
+    unless problems.empty?
+      coverage_error = RuntimeError.new(
+        "Rails coverage validation failed (#{problems.join(", ")}): " \
+        "path=#{rails_result}, started_at=#{coverage_started_at}, " \
+        "mtime=#{rails_mtime || "missing"}, commands=#{rails_commands || "unavailable"}, " \
+        "rails_recorded_at=#{rails_recorded_at || "missing"}",
+      )
     end
   end
 
@@ -169,8 +190,9 @@ task :coverage do
     report_error = e
   end
 
-  warn "Coverage report failed: #{report_error.message}" if test_error && report_error
-  raise test_error if test_error
+  primary_error = test_error || coverage_error
+  warn "Coverage report failed: #{report_error.message}" if primary_error && report_error
+  raise primary_error if primary_error
   raise report_error if report_error
 end
 

--- a/test/rails/overrides/coverage.rb
+++ b/test/rails/overrides/coverage.rb
@@ -1,14 +1,17 @@
-if ENV['COVERAGE'] && ENV['JPMOBILE_GEM_ROOT']
-  # Descendants would overwrite the Rails resultset with nearly empty coverage under the same command name.
-  ENV['RUBYOPT'] = ENV.fetch('RUBYOPT', '').split.reject {|option| option == '-r./coverage.rb' }.join(' ')
-  ENV.delete('RUBYOPT') if ENV['RUBYOPT'].empty?
+gem_root = ENV.fetch('JPMOBILE_GEM_ROOT', nil)
+if ENV.fetch('COVERAGE', nil) && gem_root
+  launcher = ENV.delete('JPMOBILE_COVERAGE_LAUNCHER')
+  unless launcher
+    ENV['RUBYOPT'] = ENV.fetch('RUBYOPT', '').split.reject {|option| option == '-r./coverage.rb' }.join(' ')
+    ENV.delete('RUBYOPT') if ENV['RUBYOPT'].empty?
+  end
 
   require 'simplecov'
 
   SimpleCov.root(File.expand_path('vendor/jpmobile', __dir__))
-  SimpleCov.coverage_dir(File.join(ENV['JPMOBILE_GEM_ROOT'], 'coverage', 'rails'))
+  SimpleCov.coverage_dir(File.join(gem_root, 'coverage', 'rails'))
   SimpleCov.start do
-    command_name 'rails'
+    command_name launcher ? 'rails-launcher' : 'rails'
     track_files 'lib/**/*.rb'
     # Host-app files cannot be merged with the in-process jpmobile runs.
     add_filter {|src| !src.filename.include?('/vendor/jpmobile/lib/') }

--- a/test/rails/overrides/coverage.rb
+++ b/test/rails/overrides/coverage.rb
@@ -2,6 +2,7 @@ gem_root = ENV.fetch('JPMOBILE_GEM_ROOT', nil)
 if ENV.fetch('COVERAGE', nil) && gem_root
   launcher = ENV.delete('JPMOBILE_COVERAGE_LAUNCHER')
   unless launcher
+    # RSpec runs in a child Ruby; strip here so that child is covered but its descendants are not.
     ENV['RUBYOPT'] = ENV.fetch('RUBYOPT', '').split.reject {|option| option == '-r./coverage.rb' }.join(' ')
     ENV.delete('RUBYOPT') if ENV['RUBYOPT'].empty?
   end


### PR DESCRIPTION
## 概要

#508 でマージしたカバレッジ計測が、Rails ランについて機能していなかった。原因は 2 つあり、いずれもこの PR で修正する。あわせて、同じ見落としが再発しないよう `rake coverage` に検証を入れる。

**現在の main の CI は Rails ランのカバレッジを取得していない。**

## 背景・課題

### 不具合 A: `rake coverage` では Rails ランが一切計測されない

`Bundler.with_unbundled_env` は Bundler がロードされた時点の環境スナップショットへ戻す。`rake coverage` は自プロセス内で `ENV['COVERAGE']` を立てるため、この値はブロック内では消えている。

```
initial=nil / after_set="1" / inside_unbundled=nil / after_block="1"
```

`test:rails` は `with_unbundled_env` の内側で `COVERAGE` を判定していたので、常に「カバレッジなし」の分岐に入り、`RUBYOPT` による bootstrap が渡らなかった。

これは #482 以来の不具合。`COVERAGE=1 rake test` はシェルで渡した値が Bundler ロード前から存在するため動いており、そちらだけが使われている間は表面化しなかった。#508 で CI を `rake coverage` に切り替えたことで、CI が何も測らない状態になった。

### 不具合 B: `RUBYOPT` の strip が計測すべき子プロセスを止めていた

`bin/rails spec` は `RSpec::Core::RakeTask#run_task` が別 Ruby の `exe/rspec` を spawn し、その子が実際に spec を走らせる。

#508 の「子孫が空の resultset で上書きするのを防ぐ」修正は `RUBYOPT` から `-r` を落としたが、上書きの原因ではないこの子プロセスまで止めていた。

| | Rails ランの計測ファイル数 |
|---|---|
| strip あり（現在の main） | 24 |
| strip なし | 54 |

### なぜ気づかれなかったか

#508 で報告・確認した「54 ファイル」は、strip を入れる前の実行で生成された `coverage/rails/.resultset.json` が残っていたもの。実装者もレビュアーも resultset の**中身**は確認したが、その実行で**新しく生成されたか**を確認していなかった。mtime を見れば分かった。

## 変更点

**COVERAGE を子へ明示的に渡す** — `with_unbundled_env` に入る前に値を取り、`system` の env ハッシュへ `JPMOBILE_GEM_ROOT` と同様に渡す。`COVERAGE=1 rake test` の既存経路はそのまま動く。

**launcher と rspec 子で役割を分ける** — 親 (`bin/rails`) にだけ `JPMOBILE_COVERAGE_LAUNCHER` を渡す。bootstrap はこれを `ENV.delete` で読み取り、親では `RUBYOPT` を保持して rspec 子へ渡し、子では strip して孫への伝播を止める。`command_name` を `rails-launcher` / `rails` に分けるので互いに上書きしない。

親を計測しているのは `lib/jpmobile/version.rb` のため。`jpmobile.gemspec` が先頭でこれを `require_relative` しており、`bundler/setup` が gemspec を読むのは他ランの `SimpleCov.start` より前になる。親は `RUBYOPT` で gemspec より先に開始するので拾える。子だけを計測する案では和集合が 53 に減る。

**計測できていなければ `rake coverage` を失敗させる** — テストが通ったあと、`coverage/rails/.resultset.json` について次を検証する。

- ファイルが存在し、mtime がこの実行以降であること
- `rails` コマンドのエントリがあること（**不具合 B が再発すれば、launcher だけが書いた新しいファイルはここで落ちる**）
- そのエントリの timestamp がこの実行以降であること
- JSON が読めて、期待する形になっていること

失敗しても `coverage:report` は実行するので、unit/rack が出した分は残る。テスト自体が失敗した場合はこの検証を行わず、元のテスト失敗をそのまま返す。

## 効果

クリーンな `coverage/` からの `rake coverage`（実装者と director が独立に実施し、一致を確認）:

| 指標 | 値 |
|---|---|
| 追跡ファイル | 58 / 58 |
| Line | 1761/1903 = **92.54%** |
| Branch | 460/590 = **77.97%** |
| Rails resultset | `rails` 53 + `rails-launcher` 24 = 和集合 **54** |

`lcov.info` とも一致（`LF=1903 LH=1761` / `BRF=590 BRH=460`）。resultset の mtime と `rails` エントリの timestamp が実行開始以降であることを確認済み。

これまで報告されていた分母 1957 は、`coverage:report` の `SimpleCov.collate` が結合した command_name を `.resultset.json` へ書き戻し、次回実行時に `use_merging` がそれも取り込む挙動で汚染されていた値。1903 が正しい。

## 検証

新しい検証が実際に機能することを、失敗させるべき状態を作って確認した。いずれも `coverage:report` が動いたうえで exit 1 する。

| 状態 | 報告される原因 |
|---|---|
| launcher だけが書いた（不具合 B の再現） | `command "rails" is missing` |
| resultset がない | `result is missing` |
| 古い resultset が残っている | `result is stale`, `command "rails" is stale` |
| 不正な JSON | `result is invalid JSON` |
| JSON が配列 / `null` | `result is Array` / `NilClass, expected a JSON object` |
| `rails` の値が配列 | `command "rails" is Array, expected a JSON object` |
| 読み取れない（EISDIR / EACCES） | `result could not be read (Errno::...)` |

メッセージにはパス、`started_at`、mtime、commands、`rails_recorded_at` が入る。

- `bundle exec rubocop` … 161 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- テスト失敗時に `coverage:report` が動き、元のテスト失敗が返ることを確認
- `rake coverage:report` の単独実行は従来どおり
