### PR TITLE
Run the Sinatra suite and fix the template cache ignoring mobile variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,6 @@ group :test do
   gem 'simplecov', require: false
   gem 'simplecov_json_formatter', require: false
   gem 'simplecov-lcov', require: false
+  gem 'sinatra'
+  gem 'test-unit'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mustermann (3.1.1)
     net-imap (0.6.6)
       date
       net-protocol
@@ -157,6 +158,7 @@ GEM
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
+    power_assert (3.1.0)
     pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
@@ -173,6 +175,10 @@ GEM
     public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -279,6 +285,13 @@ GEM
     simplecov (1.1.1)
     simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
     steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -299,7 +312,10 @@ GEM
     strscan (3.1.8)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    test-unit (3.7.8)
+      power_assert
     thor (1.5.0)
+    tilt (2.9.0)
     timeout (0.6.1)
     track_open_instances (0.1.15)
     tsort (0.2.0)
@@ -339,7 +355,9 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   simplecov_json_formatter
+  sinatra
   steep
+  test-unit
 
 BUNDLED WITH
   4.0.14

--- a/Rakefile
+++ b/Rakefile
@@ -50,5 +50,5 @@ namespace :test do
   end
 end
 
-task :test => ['test:prepare', 'spec:unit', 'spec:rack', 'test:rails']
+task :test => ['test:prepare', 'spec:unit', 'spec:rack', 'test:sinatra', 'test:rails']
 load 'lib/tasks/jpmobile_tasks.rake'

--- a/lib/jpmobile/sinatra.rb
+++ b/lib/jpmobile/sinatra.rb
@@ -1,10 +1,39 @@
 module Jpmobile
   module Sinatra
     class Base < ::Sinatra::Base
+      class VariantViews
+        def initialize(views, variants)
+          @path = views.respond_to?(:to_path) ? views.to_path : views.to_s
+          @variants = variants
+        end
+
+        def to_path
+          path
+        end
+
+        alias_method :to_str, :to_path
+
+        def hash
+          [path, variants].hash
+        end
+
+        def eql?(other)
+          other.is_a?(self.class) && path.eql?(other.path) && variants.eql?(other.variants)
+        end
+
+        protected
+
+        attr_reader :path, :variants
+      end
+      private_constant :VariantViews
+
       def render(engine, data, options = {}, locals = {}, &)
         variants = env['rack.jpmobile']&.variants
         # Sinatra caches symbol templates without including the path selected by find_template.
-        options = options.merge(jpmobile_variants: variants.dup.freeze) if variants&.any?
+        if variants&.any?
+          views = options.fetch(:views) { settings.views || './views' }
+          options = options.merge(views: VariantViews.new(views, variants.dup.freeze))
+        end
         super
       end
 

--- a/lib/jpmobile/sinatra.rb
+++ b/lib/jpmobile/sinatra.rb
@@ -1,6 +1,13 @@
 module Jpmobile
   module Sinatra
     class Base < ::Sinatra::Base
+      def render(engine, data, options = {}, locals = {}, &)
+        variants = env['rack.jpmobile']&.variants
+        # Sinatra caches symbol templates without including the path selected by find_template.
+        options = options.merge(jpmobile_variants: variants.dup.freeze) if variants&.any?
+        super
+      end
+
       # Calls the given block for every possible template file in views,
       # named name.ext, where ext is registered on engine.
       def find_template(views, name, engine)

--- a/lib/jpmobile/sinatra.rb
+++ b/lib/jpmobile/sinatra.rb
@@ -12,6 +12,7 @@ module Jpmobile
         end
 
         alias_method :to_str, :to_path
+        alias_method :to_s, :to_path
 
         def hash
           [path, variants].hash
@@ -31,7 +32,7 @@ module Jpmobile
         variants = env['rack.jpmobile']&.variants
         # Sinatra caches symbol templates without including the path selected by find_template.
         if variants&.any?
-          views = options.fetch(:views) { settings.views || './views' }
+          views = options[:views] || settings.views || './views'
           options = options.merge(views: VariantViews.new(views, variants.dup.freeze))
         end
         super

--- a/lib/tasks/jpmobile_tasks.rake
+++ b/lib/tasks/jpmobile_tasks.rake
@@ -139,7 +139,6 @@ namespace :test do
     t.libs << 'lib'
     t.libs << 'test/sinatra'
     t.pattern = 'test/sinatra/test/*_test.rb'
-    t.verbose = true
   end
 end
 

--- a/sig/jpmobile/sinatra.rbs
+++ b/sig/jpmobile/sinatra.rbs
@@ -1,6 +1,8 @@
 module Jpmobile
   module Sinatra
     class Base < ::Sinatra::Base
+      def render: (untyped engine, untyped data, ?Hash[untyped, untyped] options, ?Hash[untyped, untyped] locals) ?{ (*untyped) -> untyped } -> untyped
+
       # Calls the given block for every possible template file in views,
       # named name.ext, where ext is registered on engine.
       def find_template: (untyped views, untyped name, untyped engine) { (untyped) -> untyped } -> untyped

--- a/sig/jpmobile/sinatra.rbs
+++ b/sig/jpmobile/sinatra.rbs
@@ -5,6 +5,7 @@ module Jpmobile
         def initialize: (untyped views, Array[untyped] variants) -> void
         def to_path: () -> String
         alias to_str to_path
+        alias to_s to_path
         def hash: () -> Integer
         def eql?: (untyped other) -> bool
 

--- a/sig/jpmobile/sinatra.rbs
+++ b/sig/jpmobile/sinatra.rbs
@@ -1,6 +1,18 @@
 module Jpmobile
   module Sinatra
     class Base < ::Sinatra::Base
+      class VariantViews
+        def initialize: (untyped views, Array[untyped] variants) -> void
+        def to_path: () -> String
+        alias to_str to_path
+        def hash: () -> Integer
+        def eql?: (untyped other) -> bool
+
+        protected
+        attr_reader path: String
+        attr_reader variants: Array[untyped]
+      end
+
       def render: (untyped engine, untyped data, ?Hash[untyped, untyped] options, ?Hash[untyped, untyped] locals) ?{ (*untyped) -> untyped } -> untyped
 
       # Calls the given block for every possible template file in views,

--- a/test/sinatra/guestbook.rb
+++ b/test/sinatra/guestbook.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'sinatra'
 require File.join(File.dirname(__FILE__), '../../lib/jpmobile')
-require 'jpmobile/rack'
 require 'singleton'
 
 require 'jpmobile/sinatra'
@@ -13,9 +12,11 @@ class SinatraTestHelper
 end
 
 class Guestbook < Jpmobile::Sinatra::Base
-  use Jpmobile::Rack::MobileCarrier
-  use Jpmobile::Rack::ParamsFilter
-  use Jpmobile::Rack::Filter
+  set :environment, :test
+
+  use Jpmobile::MobileCarrier
+  use Jpmobile::ParamsFilter
+  use Jpmobile::Filter
 
   def call(env)
     _dup = dup

--- a/test/sinatra/test/filter_test.rb
+++ b/test/sinatra/test/filter_test.rb
@@ -41,13 +41,19 @@ class SinatraOnJpmobile < Test::Unit::TestCase
     assert_equal last_response.body, utf8_to_sjis('けーたい')
   end
 
-  def test_view_selector_pc
+  def test_view_selector_pc_then_mobile
     get '/top', {}, { 'HTTP_USER_AGENT' => 'Mozilla' }
     assert_equal 'PC', last_response.body.strip
-  end
 
-  def test_view_selector_mobile
     get '/top', {}, { 'HTTP_USER_AGENT' => 'DoCoMo/2.0 SH902i(c100;TB;W24H12)' }
     assert_equal 'MOBILE', last_response.body.strip
+  end
+
+  def test_view_selector_mobile_then_pc
+    get '/top', {}, { 'HTTP_USER_AGENT' => 'DoCoMo/2.0 SH902i(c100;TB;W24H12)' }
+    assert_equal 'MOBILE', last_response.body.strip
+
+    get '/top', {}, { 'HTTP_USER_AGENT' => 'Mozilla' }
+    assert_equal 'PC', last_response.body.strip
   end
 end

--- a/test/sinatra/test/filter_test.rb
+++ b/test/sinatra/test/filter_test.rb
@@ -41,13 +41,13 @@ class SinatraOnJpmobile < Test::Unit::TestCase
     assert_equal last_response.body, utf8_to_sjis('けーたい')
   end
 
-  # def test_view_selector_pc
-  #   get '/top', {}, {"HTTP_USER_AGENT" => "Mozilla"}
-  #   assert_equal last_response.body, 'PC'
-  # end
+  def test_view_selector_pc
+    get '/top', {}, { 'HTTP_USER_AGENT' => 'Mozilla' }
+    assert_equal 'PC', last_response.body.strip
+  end
 
-  # def test_view_selector_mobile
-  #   get '/top', {}, {"HTTP_USER_AGENT" => "DoCoMo/2.0 SH902i(c100;TB;W24H12)"}
-  #   assert_equal last_response.body, 'MOBILE'
-  # end
+  def test_view_selector_mobile
+    get '/top', {}, { 'HTTP_USER_AGENT' => 'DoCoMo/2.0 SH902i(c100;TB;W24H12)' }
+    assert_equal 'MOBILE', last_response.body.strip
+  end
 end

--- a/test/sinatra/test/filter_test.rb
+++ b/test/sinatra/test/filter_test.rb
@@ -1,3 +1,8 @@
+if ENV['COVERAGE']
+  require_relative '../../../spec/support/coverage'
+  JpmobileCoverage.start('sinatra')
+end
+
 require 'guestbook'
 require 'rack/test'
 require 'test/unit'


### PR DESCRIPTION
## 概要

`test/sinatra` にあるテストスイートを `rake test` に接続する。接続の過程で、`Jpmobile::Sinatra::Base` がモバイル用テンプレートを取り違えて配信する不具合が見つかったので、あわせて修正する。

## 背景・課題

`lib/jpmobile/sinatra.rb` のカバレッジは 0% だった。テストが無いからではなく、`test/sinatra` にある 4 つのテストと `test:sinatra` タスクが `rake test` から呼ばれていなかったため。

そしてスイートはそもそも実行できない状態だった。

- `guestbook.rb` が `require 'jpmobile/rack'` していたが、`lib/jpmobile/rack.rb` は存在しない
- `Jpmobile::Rack::MobileCarrier` などを参照していたが、jpmobile が autoload するのは `Jpmobile` 直下の定数（rack spec と README もそちらを使っている）
- `sinatra` と `test-unit` が bundle に無い

### 見つかった不具合: variant を跨いだテンプレートの誤配信

`Jpmobile::Sinatra::Base#find_template` はモバイル variant に応じて `index_mobile.erb` などを選ぶ。ところが Sinatra はコンパイル済みテンプレートを engine / data / options / views をキーにキャッシュしており、**`find_template` が選んだ variant はキーに入らない**。

その結果、先に到達したリクエストが勝つ。DoCoMo 向けにレンダリングされたページが、次に来た PC の訪問者へキャッシュから返る。逆も起きる。`find_template` はキャッシュミス時にしか呼ばれないため、そのオーバーライドだけでは直せない。

このケースを検証するテストは `filter_test.rb` に書かれていたが、コメントアウトされていた。

## 変更点

**スイートを実行可能にして `rake test` へ接続**

- `guestbook.rb` を実在する公開 API（`Jpmobile::MobileCarrier` / `ParamsFilter` / `Filter`）へ向ける。`Jpmobile::Rack` 名前空間を新設して合わせる方向は採らなかった
- `sinatra` / `test-unit` を Gemfile の test group へ追加
- Sinatra 4.2 は test 環境でないとテスト用ホストを拒否するため、fixture を `set :environment, :test` に
- Rake 13.4.2 の `TestTask` は `verbose = true` のとき末尾に `-v` を付ける。今の test-unit はそれをバージョン要求と解釈して起動に失敗するので、このフラグを外す
- `COVERAGE` 指定時のみ、unit / rack と同じ形で SimpleCov を起動（`command_name 'sinatra'`）

**テンプレートキャッシュを variant 別に分ける**

`#render` で、リクエストに variant があるときだけ `:views` を差し替える。Sinatra は `:views` をコンパイル前に取り出してキャッシュキーの一部にするので、これで variant ごとにキャッシュが分かれる。渡すオブジェクトは `to_path` / `to_s` / `to_str` で元と同じパスを返し、`hash` と `eql?` だけが variant を含む。

variant が無い場合（PC）はオブジェクトを被せず、そのまま `super` を呼ぶので経路は変わらない。

キャッシュを無効化する方向は採らなかった。同じ症状は消せるが、不具合を隠したまま毎リクエストでテンプレートを再コンパイルすることになる。

**コメントアウトされていた view selector テストを復活**

修正前のコードに対して失敗することを確認したうえで復活させた。Test::Unit はメソッド名順に実行するため、片方向だけのテストでは実行順に依存して見逃す。各テストが PC とモバイルの両方のリクエストを出す形にしたので、1 本だけ実行しても誤配信を検出できる。

比較は `body.strip` で行う。モバイル側はフィルタが末尾を CRLF に変えるが、それはどちらのテンプレートが選ばれたかとは無関係なため。

## 効果

`rake coverage`（`coverage/` を空にしてから 1 回実行）:

| 指標 | #509 時点の main | この PR |
|---|---|---|
| Line | 1761/1903 (92.54%) | **1790/1924 (93.04%)** |
| Branch | 460/590 (77.97%) | **470/598 (78.60%)** |
| `lib/jpmobile/sinatra.rb` Line | 0 / 14 | **29/29 (100%)** |
| `lib/jpmobile/sinatra.rb` Branch | 0 / 0 | **10/10 (100%)** |

Line 0% のファイルは `lib/jpmobile/session/mem_cache_store.rb` の 1 件だけになった。

## 検証

- `bundle exec rake test:sinatra` … 6 tests, 10 assertions, 0 failures
- `bundle exec rake coverage` … unit 361 / rack 152 (8 pending) / sinatra 6 / Rails 279、失敗 0
- テンプレートキャッシュの修正を外すと、view selector テストが両方向とも単独実行で失敗することを確認
- `bundle exec rubocop` … 161 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
