### PR TITLE
Cover the emoticon conversion fallbacks

### DIFF
--- a/spec/unit/emoticon_spec.rb
+++ b/spec/unit/emoticon_spec.rb
@@ -61,6 +61,28 @@ describe Jpmobile::Emoticon do
     it 'should not convert 〓' do
       expect(Jpmobile::Emoticon.unicodecr_to_external('&#x3013;', Jpmobile::Emoticon::CONVERSION_TABLE_TO_GOOGLE_EMOTICON, false)).to eq('〓')
     end
+
+    it 'should preserve a numeric character reference without a carrier mapping' do
+      expect(Jpmobile::Emoticon.unicodecr_to_external('&#x2600;', Jpmobile::Emoticon::CONVERSION_TABLE_TO_DOCOMO)).to eq('&#x2600;')
+    end
+
+    it 'should preserve a numeric character reference that is not a carrier emoticon' do
+      expect(Jpmobile::Emoticon.unicodecr_to_external('&#x3042;')).to eq('&#x3042;')
+    end
+
+    it 'should preserve geta when no conversion table is specified' do
+      expect(Jpmobile::Emoticon.unicodecr_to_external('&#x3013;')).to eq('〓')
+    end
+
+    it 'should return a carrier emoticon as utf8 when Shift_JIS output is disabled' do
+      expect(Jpmobile::Emoticon.unicodecr_to_external('&#xe63e;', nil, false)).to eq([0xe63e].pack('U'))
+    end
+
+    it 'should use a readable substitute when the target carrier has no equivalent emoticon' do
+      converted = Jpmobile::Emoticon.unicodecr_to_external('&#xe6d1;', Jpmobile::Emoticon::CONVERSION_TABLE_TO_AU)
+
+      expect(converted).to eq(sjis("\x81\x6d\x82\x89\x83\x82\x81\x5b\x83\x68\x81\x6e"))
+    end
   end
 
   describe 'unicodecr_to_utf8' do
@@ -71,6 +93,10 @@ describe Jpmobile::Emoticon do
       expect(Jpmobile::Emoticon.unicodecr_to_utf8('&#xe481;')).to eq(utf8("\356\222\201"))
       # softbank codepoint
       expect(Jpmobile::Emoticon.unicodecr_to_utf8('&#xf001;')).to eq(utf8("\xef\x80\x81"))
+    end
+
+    it 'should preserve a numeric character reference that is not a carrier emoticon' do
+      expect(Jpmobile::Emoticon.unicodecr_to_utf8('&#x2600;')).to eq('&#x2600;')
     end
   end
 
@@ -114,6 +140,14 @@ describe Jpmobile::Emoticon do
       it 'should not convert 〓' do
         expect(Jpmobile::Emoticon.external_to_unicodecr_unicode60('〓')).to eq('〓')
       end
+
+      it 'should convert a keycap sequence as one Unicode 6.0 emoticon' do
+        expect(Jpmobile::Emoticon.external_to_unicodecr_unicode60([0x31, 0x20e3].pack('U*'))).to eq('&#xf21c;')
+      end
+
+      it 'should use geta when a Unicode 6.0 emoticon has no carrier equivalent' do
+        expect(Jpmobile::Emoticon.external_to_unicodecr_unicode60([0x1f301].pack('U'))).to eq('〓')
+      end
     end
 
     context 'at Android emoticon' do
@@ -127,6 +161,10 @@ describe Jpmobile::Emoticon do
 
       it 'should not convert 〓' do
         expect(Jpmobile::Emoticon.external_to_unicodecr_google('〓')).to eq('〓')
+      end
+
+      it 'should use geta when a Google emoticon has no carrier equivalent' do
+        expect(Jpmobile::Emoticon.external_to_unicodecr_google([0xfe00b].pack('U'))).to eq('〓')
       end
     end
   end
@@ -147,6 +185,24 @@ describe Jpmobile::Emoticon do
 
       it 'should not include extra JIS escape sequence between Kanji-code and emoticon' do
         expect(Jpmobile::Emoticon.unicodecr_to_au_email(utf8_to_jis('&#xe481;掲示板'))).to eq(Jpmobile::Util.ascii_8bit("\x1b\x24\x42\x75\x3a\x37\x47\x3C\x28\x48\x44\x1b\x28\x42"))
+      end
+
+      it 'should use a readable substitute when au email has no equivalent emoticon' do
+        expect(Jpmobile::Emoticon.unicodecr_to_au_email('&#xe6a0;')).to eq(ascii_8bit("\x1b\x24\x42\x21\x7b\x1b\x28\x42"))
+      end
+
+      it 'should preserve a numeric character reference without an au mapping' do
+        expect(Jpmobile::Emoticon.unicodecr_to_au_email('&#x2600;')).to eq(ascii_8bit('&#x2600;'))
+      end
+    end
+
+    describe 'softbank' do
+      it 'should use a readable substitute when SoftBank email has no equivalent emoticon' do
+        expect(Jpmobile::Emoticon.unicodecr_to_softbank_email('&#xe644;')).to eq(sjis("\x81\x6d\x96\xb6\x81\x6e"))
+      end
+
+      it 'should preserve a numeric character reference without a SoftBank mapping' do
+        expect(Jpmobile::Emoticon.unicodecr_to_softbank_email('&#x2600;')).to eq('&#x2600;')
       end
     end
   end


### PR DESCRIPTION
## 概要

`Jpmobile::Emoticon` の分岐カバレッジを 35/66 から 46/66 へ引き上げる。テストの追加のみで、`lib/` は変更していない。

## 背景

#508 / #509 / #510 で計測が正しくなり、初めて信頼できるベースラインが取れた。その結果、`emoticon.rb` は未カバー分岐 31 と `mail.rb` と並んで最多で、2 ファイルで全体の 48% を占めることが分かった。

未カバーの内訳を見ると、そのほとんどが**変換できなかったときの振る舞い**だった。既存のテストは「変換できる絵文字」を確認していて、「変換できない絵文字」を確認していない。

## 変更点

呼び出し側が実際に到達する経路にテストを追加した。

- 変換先の表にエントリが無い数値文字参照は、壊さずそのまま返す。他キャリアの絵文字でも、絵文字でない文字でも、メール用エンコーディングでも同じ
- キャリアに同等の絵文字が無い Unicode 6.0 / Google 絵文字は 〓 になる
- キーキャップ列は 2 つのコードポイントではなく 1 つの絵文字として変換される
- キャリアに同等の絵文字が無い場合、変換表の可読な代替文字列がそのキャリアのエンコーディングで出力される（［ｉモード］/ ○ / ［霧］）
- Shift_JIS 出力を無効にすると、私的領域のコードポイントが UTF-8 で返る

入力は実在のコードポイントのみを使い、期待値は変換表から導いた。

## 埋めなかった分岐

8 分岐は残した。いずれも公開メソッド経由では到達できない。正規表現が、参照先と同じ表から生成されているため。

- `DOCOMO_SJIS_REGEXP` / `AU_SJIS_REGEXP` は各 Hash のキーから作られるので、マッチした値の参照が nil になる入力は無い
- Unicode 6.0 / Google の表の値は Integer か String のみ（Integer 746 + String 3 / Integer 803 + String 2）で、`case` の暗黙 else に入る型が無い
- Google の表のキー 805 件はすべて Integer で、複数コードポイントのキーが無い
- `CONVERSION_TABLE_TO_AU` の Integer 値 1320 件はすべて `UNICODE_TO_SJIS` に存在し、そこから得た SJIS もすべて `SJIS_TO_EMAIL_JIS` に存在する
- `CONVERSION_TABLE_TO_SOFTBANK` の Integer 値 1172 件もすべて `SOFTBANK_UNICODE_TO_SJIS` に存在する

これらに到達するには、ライブラリが決して構築しない表を渡すしかない。モックや作為的な変換表で通すことはしていない。

## 効果

| 指標 | main | この PR |
|---|---|---|
| `lib/jpmobile/emoticon.rb` Line | 122/152 (80.26%) | **132/152 (86.84%)** |
| `lib/jpmobile/emoticon.rb` Branch | 35/66 (53.03%) | **46/66 (69.70%)** |
| 全体 Line | 1790/1924 (93.04%) | **1800/1924 (93.56%)** |
| 全体 Branch | 470/598 (78.60%) | **481/598 (80.43%)** |

## 別途報告

この作業中に、Unicode の国旗シーケンスが正しく変換されないことが分かった。

`UNICODE_EMOTICON_TO_CARRIER_EMOTICON` には 2 文字の regional indicator を配列キーとする国旗が 10 件あるが、同じ表に regional indicator 単体 26 文字も入っており、`UNICODE_EMOTICON_REGEXP` の `Regexp.union` は単体を先に試す。結果、🇯🇵 (U+1F1EF U+1F1F5、表では U+F50B) は 1 文字ずつ処理されて `〓〓` になる。キーキャップ列が正しく動くのは、その構成要素が単体キーに無いため。

この PR はテストの追加だけなので `lib/` は触らず、失敗するテストも入れていない。修正は別の PR で行う。

## 検証

- `bundle exec rake coverage` … unit 374 (既存 361 + 13) / rack 152 (8 pending) / sinatra 6 / Rails 279、失敗 0
- `bundle exec rubocop` … 161 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- `coverage/` を空にしてからの計測で、上記の数値と `lcov.info` (LF=1924 LH=1800 / BRF=598 BRH=481) が一致
