### PR TITLE
Cover the mail header and structure branches

### DIFF
--- a/spec/unit/decorated_mail_spec.rb
+++ b/spec/unit/decorated_mail_spec.rb
@@ -19,6 +19,58 @@ describe 'decorated mails' do
     @inline_url = @mail.attachments['photo.jpg'].url
   end
 
+  it 'leaves a non-decoratable mail structure unchanged' do
+    @mail.mobile = Jpmobile::Mobile::AbstractMobile.new(nil, nil)
+    original_parts = @mail.parts.dup
+
+    @mail.rearrange!
+
+    expect(@mail.parts).to eq(original_parts)
+  end
+
+  it 'does not add a charset to a carrier multipart container' do
+    @mail.content_type = 'multipart/mixed'
+    @mail.mobile = Jpmobile::Mobile::Au.new(nil, nil)
+
+    @mail.add_charset
+
+    expect(@mail.header['Content-Type'].parameters['charset']).to be_nil
+  end
+
+  it 'builds a decorated mail with only a text body' do
+    @mail.mobile = Jpmobile::Mobile::Au.new(nil, nil)
+
+    @mail.rearrange!
+
+    expect(@mail.find_part_by_content_type('text/plain').size).to eq(1)
+    expect(@mail.find_part_by_content_type('text/html')).to be_empty
+    expect(@mail.attachments.map(&:filename)).to include('photo.jpg')
+  end
+
+  it 'builds a decorated mail with only an html body' do
+    mail = Mail.new
+    mail.html_part = Mail::Part.new do
+      content_type 'text/html; charset=ISO-2022-JP'
+      body '<p>本文</p>'
+    end
+    mail.mobile = Jpmobile::Mobile::Au.new(nil, nil)
+
+    mail.rearrange!
+
+    expect(mail.find_part_by_content_type('text/plain')).to be_empty
+    expect(mail.find_part_by_content_type('text/html').size).to eq(1)
+  end
+
+  it 'keeps regular and non-image inline attachments outside the alternative body' do
+    @mail.attachments['document.txt'] = 'document'
+    @mail.attachments.inline['notes.txt'] = 'notes'
+    @mail.mobile = Jpmobile::Mobile::Au.new(nil, nil)
+
+    @mail.rearrange!
+
+    expect(@mail.attachments.map(&:filename)).to contain_exactly('photo.jpg', 'document.txt', 'notes.txt')
+  end
+
   describe 'docomo' do
     before(:each) do
       inline_url = @inline_url

--- a/spec/unit/mail_spec.rb
+++ b/spec/unit/mail_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+require 'base64'
 require 'mail'
 require 'jpmobile/mail'
 
@@ -41,6 +42,23 @@ describe 'Jpmobile::Mail' do
           expect(subject.parts[1].body.to_s).to eq(ascii_8bit('ほげほげ'))
         end
       end
+    end
+
+    it 'keeps the carrier-selected charset when clearing its mobile' do
+      @mail.charset = nil
+      @mail.mobile = Jpmobile::Mobile::Docomo.new(nil, nil)
+      @mail.mobile = nil
+
+      expect(@mail.charset).to eq('Shift_JIS')
+    end
+
+    it 'keeps address fields valid when carrier conversion is disabled' do
+      @mail.to = 'reader@example.com'
+      @mail[:from].mobile = nil
+      @mail[:to].mobile = nil
+
+      expect(@mail.from).to eq(['info@jpmobile-rails.org'])
+      expect(@mail.to).to eq(['reader@example.com'])
     end
   end
 
@@ -104,6 +122,12 @@ describe 'Jpmobile::Mail' do
 
         expect(@mail.to_s).to match(Regexp.escape('=?Shift_JIS?B?lpyXdPif?='))
         expect(@mail.to_s).to match(sjis_regexp("\xF8\x9F"))
+      end
+
+      it 'should not encode an already encoded carrier subject again' do
+        @mail.subject = '=?Shift_JIS?B?lpyXdA==?='
+
+        expect(@mail.encoded.scan('=?Shift_JIS?B?lpyXdA==?=').size).to eq(1)
       end
     end
   end
@@ -311,6 +335,35 @@ describe 'Jpmobile::Mail' do
         @mail.to_s
       }.not_to raise_error
     end
+
+    it 'makes a raw non-ASCII Content-Type name safe for a MIME header' do
+      part = Mail::Part.new
+      part.content_type = 'image/jpeg; name="日本語.jpg"'
+
+      expect(part.header['Content-Type'].parameters['name']).to eq(Base64.strict_encode64('日本語.jpg'))
+    end
+
+    it 'makes a raw non-ASCII Content-Disposition filename safe for a MIME header' do
+      part = Mail::Part.new
+      part.content_disposition = 'attachment; filename="日本語.jpg"'
+
+      expect(part.header['Content-Disposition'].parameters['filename']).to eq(Base64.strict_encode64('日本語.jpg'))
+    end
+
+    it 'preserves an ASCII Content-Location filename' do
+      part = Mail::Part.new
+      part.content_location = 'image.jpg'
+
+      expect(part.content_location).to eq('image.jpg')
+    end
+  end
+
+  context 'header charset' do
+    it 'decodes ISO-2022-JP optional fields into UTF-8' do
+      field = Mail::OptionalField.new('X-Test', 'value', 'ISO-2022-JP')
+
+      expect(field.charset).to eq('UTF-8')
+    end
   end
 
   context 'encoding conversion' do
@@ -331,6 +384,18 @@ describe 'Jpmobile::Mail' do
       @mail.body = "10:00#{[0xff5e].pack("U")}12:00"
 
       expect(ascii_8bit(@mail.to_s)).to match(Regexp.compile(Regexp.escape(ascii_8bit("\x31\x30\x3a\x30\x30\x1b\x24\x42\x21\x41\x1b\x28\x42\x31\x32\x3a\x30\x30"))))
+    end
+
+    it 'decodes a transfer-encoded carrier text body when assigning its mobile' do
+      body = Mail::Body.new([utf8_to_sjis('ほげ')].pack('m0'))
+      body.encoding = 'base64'
+      body.charset = 'Shift_JIS'
+      body.content_type_with_jpmobile = 'text/plain'
+
+      body.mobile = Jpmobile::Mobile::Docomo.new(nil, nil)
+
+      expect(body.to_s).to eq('ほげ')
+      expect(body.encoding).to eq('7bit')
     end
   end
 

--- a/spec/unit/receive_mail_spec.rb
+++ b/spec/unit/receive_mail_spec.rb
@@ -245,6 +245,24 @@ describe 'Jpmobile::Mail#receive' do
         expect(@mail.body.to_s).to eq("テスト本文\n\n")
       end
     end
+
+    it 'decodes a Q-encoded subject and base64 text body from a carrier mail' do
+      encoded_body = [utf8_to_sjis('ほげ')].pack('m0')
+      raw_mail = <<~MAIL.gsub("\n", "\r\n")
+        From: sender@docomo.ne.jp
+        Subject: =?Shift_JIS?Q?test=20subject?=
+        Content-Type: text/plain; charset=Shift_JIS
+        Content-Transfer-Encoding: base64
+
+        #{encoded_body}
+      MAIL
+
+      mail = Mail.new(raw_mail)
+
+      expect(mail.subject).to eq('test subject')
+      expect(mail.body.to_s).to eq('ほげ')
+      expect(mail.content_transfer_encoding).to eq('8bit')
+    end
   end
 
   describe 'Au' do


### PR DESCRIPTION
## 概要

`Jpmobile::Mail` の分岐カバレッジを 99/130 から 117/130 へ引き上げる。テストの追加のみで、`lib/` は変更していない。

## 背景

`mail.rb` は未カバー分岐 31 で、単一ファイルとして最大の穴だった。既存のテストはキャリア向けに変換したり構造を組み替えたりする経路を押さえていて、その周辺 — 受け取ったメールが持っているヘッダパラメータ、本文パートが片方しかないメール、キャリア変換を外して素の Mail の挙動に戻す場合 — が抜けていた。

## 変更点

- 生の `Content-Type` / `Content-Disposition` パラメータの `name` / `filename` に非 ASCII が含まれる場合、ヘッダを ASCII に保つため base64 エンコードされる。ASCII の `Content-Location` はそのまま残る
- `ISO-2022-JP` の optional field は `UTF-8` を返す。値がそこへデコードされているため
- field の mobile を外しても、キャリアが選んだ charset は保たれ、アドレスも壊れない
- 既にキャリアのエンコーディングを持つ件名は二度エンコードされない
- mobile を割り当てたキャリア本文は、アクセスのたびではなく一度だけデコードされる
- text パートだけ、あるいは html パートだけのメールを組み替えても alternative 構造になり、添付（通常のものも、画像でない inline のものも）はその外に残る

## 埋めなかった分岐

13 分岐は残した。いずれも到達が面倒だからではなく、公開 API を通しては到達できないため。

- 6 つは手前の処理で塞がれている。本文はデコードする分岐より前にデコード済みで、`case` の直前の正規表現はその `case` が扱う値しか捕捉せず、`Mail#attachments` は分岐が判定する filename や disposition を持つパートしか返さない
- 2 つは今の mail gem がもう投げない nil エラーへの rescue
- 1 つは `ContentLocationElement` にコピーされた同じ filename エンコード分岐。`Content-Location` は URI reference を保持し、その中の非 ASCII は quoted パラメータとして届くよりずっと前に percent-encode される
- 残り 4 つは `Mail::Sendmail.call`。このメソッドは実行できない。最後に `String#to_lf` を呼ぶが、この定義がどこにもない。無害なコマンドを渡して実際に動かすとその行で `NoMethodError` になる。失敗をテストで固定しても、壊れた実装を仕様として据えるだけなので書いていない

## 効果

| 指標 | main | この PR |
|---|---|---|
| `lib/jpmobile/mail.rb` Line | 330/362 (91.16%) | **345/362 (95.30%)** |
| `lib/jpmobile/mail.rb` Branch | 99/130 (76.15%) | **117/130 (90.00%)** |
| 全体 Line | 1790/1924 (93.04%) | **1806/1924 (93.87%)** |
| 全体 Branch | 470/598 (78.60%) | **488/598 (81.61%)** |

## 別途報告

`Mail::Sendmail.call` は呼び出せば必ず失敗する。`to_lf` は jpmobile にも mail 2.9.1 にも定義がなく、mail 本体の `Mail::Sendmail` は `.call` を持たない（この定義は jpmobile が足したもの）。リポジトリ内にこれを使うコードもない。

この PR はテストの追加だけなので触っていない。扱いは別途。

## 検証

- `bundle exec rake coverage` … unit 375 (既存 361 + 14) / rack 152 (8 pending) / sinatra 6 / Rails 279、失敗 0
- `bundle exec rubocop` … 161 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- `coverage/` を空にしてからの計測で、上記の数値と `lcov.info` (LF=1924 LH=1806 / BRF=598 BRH=488) が一致
