### PR TITLE
Cover the Rails integration branches

### DIFF
--- a/spec/unit/hankaku_filter_spec.rb
+++ b/spec/unit/hankaku_filter_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+require 'active_support'
+require 'nokogiri'
+require 'rack/mock'
+require 'rack/request'
+require 'jpmobile/rack/mobile_carrier'
+require 'jpmobile/filter'
+
+describe Jpmobile::HankakuFilter do
+  def mobile_request(user_agent)
+    env = Rack::MockRequest.env_for('/', 'HTTP_USER_AGENT' => user_agent)
+    env['rack.jpmobile'] = Jpmobile::Mobile::AbstractMobile.carrier(env)
+    Rack::Request.new(env)
+  end
+
+  it 'HTML fragment の送信ボタンを本文とともに半角へ変換すること' do
+    request = mobile_request('SoftBank/1.0/910T/TJ001/SN000000000000000 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1')
+    response = Struct.new(:body, :content_type).new('<input type="submit" value="送信ア"><p>カナ</p>', 'text/html')
+    controller = Struct.new(:request, :response, :params).new(request, response, {})
+
+    described_class.new(input: true).after(controller)
+
+    expect(response.body).to include('value="送信ｱ"', '<p>ｶﾅ</p>')
+  end
+
+  it 'Content-Type がない応答本文を変換しないこと' do
+    request = mobile_request('DoCoMo/2.0 SH906i(c100;TB;W24H16)')
+    response = Struct.new(:body, :content_type).new('アブラカダブラ', nil)
+    controller = Struct.new(:request, :response, :params).new(request, response, {})
+
+    described_class.new.after(controller)
+
+    expect(response.body).to eq('アブラカダブラ')
+  end
+
+  it '入れ子のフォームパラメータを階層を保ったまま全角へ変換すること' do
+    request = mobile_request('SoftBank/1.0/910T/TJ001/SN000000000000000 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1')
+    params = { 'profile' => { 'name' => 'ｱﾌﾞﾗ' }, 'items' => [['ｶﾀﾞ']] }
+    controller = Struct.new(:request, :response, :params).new(request, nil, params)
+
+    described_class.new.before(controller)
+
+    expect(controller.params).to eq('profile' => { 'name' => 'アブラ' }, 'items' => [['カダ']])
+  end
+end

--- a/spec/unit/request_with_mobile_spec.rb
+++ b/spec/unit/request_with_mobile_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+require 'rack/mock'
+require 'rack/request'
+require 'jpmobile/rack/mobile_carrier'
+
+describe Jpmobile::RequestWithMobile do
+  let(:generic_request_class) do
+    Class.new do
+      include Jpmobile::RequestWithMobile
+
+      attr_reader :env
+
+      def initialize(env)
+        @env = env
+      end
+    end
+  end
+
+  it 'Rack リクエストでは Rack が解決した接続元 IP を返すこと' do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/', 'REMOTE_ADDR' => '210.153.84.1'))
+
+    expect(request.remote_addr).to eq('210.153.84.1')
+  end
+
+  it '汎用リクエストではリバースプロキシが渡した接続元 IP を優先すること' do
+    request = generic_request_class.new('HTTP_X_FORWARDED_FOR' => '210.153.84.1', 'REMOTE_ADDR' => '192.0.2.1')
+
+    expect(request.remote_addr).to eq('210.153.84.1')
+  end
+
+  it 'プロキシ情報がない汎用リクエストでは直接の接続元 IP を返すこと' do
+    request = generic_request_class.new('REMOTE_ADDR' => '210.153.84.1')
+
+    expect(request.remote_addr).to eq('210.153.84.1')
+  end
+end

--- a/test/rails/overrides/app/controllers/trans_sid_base_controller.rb
+++ b/test/rails/overrides/app/controllers/trans_sid_base_controller.rb
@@ -14,6 +14,18 @@ class TransSidBaseController < ApplicationController
     redirect_to('/')
   end
 
+  def redirect_with_query
+    redirect_to('/destination?source=mobile')
+  end
+
+  def redirect_with_session
+    redirect_to('/destination?_session_id=preserved')
+  end
+
+  def redirect_action_with_session
+    redirect_to(action: 'form', _session_id: 'preserved')
+  end
+
   def session_init
     session[:jpmobile] = 'everyleaf'
     @user = User.find_by_id(1)

--- a/test/rails/overrides/config/routes.rb
+++ b/test/rails/overrides/config/routes.rb
@@ -32,6 +32,9 @@ RailsRoot::Application.routes.draw do
       redirect_path
       redirect_path_admin
       redirect_action
+      redirect_with_query
+      redirect_with_session
+      redirect_action_with_session
     ].each do |a|
       get "#{c}/#{a}", to: "#{c}##{a}"
     end

--- a/test/rails/overrides/spec/controllers/helpers_spec.rb
+++ b/test/rails/overrides/spec/controllers/helpers_spec.rb
@@ -24,6 +24,13 @@ describe LinksController, type: :controller do
   end
 
   context 'docomo で' do
+    it '直接指定した callback URL への FOMA GPS リンクだけを生成すること' do
+      request.user_agent = 'DoCoMo/2.0 SH903i(c100;TB;W24H16)'
+      links = get_href_and_texts(controller.view_context.get_position_link_to('現在地を送信', 'https://jpmobile.info/positions'))
+
+      expect(links.map {|text, _, path,| [text, path] }).to eq([['現在地を送信', 'https://jpmobile.info/positions']])
+    end
+
     it 'get_position_link_to が正常に表示されること' do
       request.user_agent = 'DoCoMo/2.0 SH903i(c100;TB;W24H16)'
       get :link
@@ -77,6 +84,12 @@ describe LinksController, type: :controller do
   end
 
   context 'au で' do
+    it 'GPS と簡易位置情報のどちらにも対応しない端末には測位リンクを生成しないこと' do
+      request.user_agent = 'KDDI-PT21 UP.Browser/6.2.0.5 (GUI) MMP/2.0'
+
+      expect(controller.view_context.get_position_link_to('現在地を送信', controller: 'links', action: 'link')).to be_empty
+    end
+
     # get_position_link_to(自動判別), au, location only
     def test_get_position_link_to_au_location_only
       request.user_agent = 'KDDI-SN26 UP.Browser/6.2.0.6.2 (GUI) MMP/2.0'

--- a/test/rails/overrides/spec/helpers/helpers_spec.rb
+++ b/test/rails/overrides/spec/helpers/helpers_spec.rb
@@ -12,4 +12,19 @@ describe Jpmobile::Helpers, type: :helper do
     # http://d.hatena.ne.jp/mizincogrammer/20090123/1232702067
     expect(softbank_location_link_to('STRING', host: 'jpmobile.info', controller: 'filter', action: 'rawdata', p: 'param')).to eq(%(<a href="location:auto?url=http://jpmobile.info/filter/rawdata&amp;p=param">STRING</a>))
   end
+
+  it '各キャリアの位置情報 URL に直接指定した callback URL が引き継がれること' do
+    callback_url = 'https://jpmobile.info/positions'
+
+    aggregate_failures do
+      expect(docomo_foma_gps_link_to('位置情報', callback_url)).to include(%(href="#{callback_url}"))
+      expect(docomo_openiarea_url_for(callback_url)).to end_with("nl=#{CGI.escape(callback_url)}")
+      expect(docomo_utn_link_to('端末情報', callback_url)).to include(%(href="#{callback_url}"))
+      expect(docomo_guid_link_to('iモードID', callback_url)).to include(%(href="#{callback_url}"))
+      expect(au_gps_url_for(callback_url)).to include("url=#{CGI.escape(callback_url)}")
+      expect(au_location_url_for(callback_url)).to include("url=#{CGI.escape(callback_url)}")
+      expect(softbank_location_url_for(callback_url.dup)).to eq("location:auto?url=#{callback_url}")
+      expect(willcom_location_url_for(callback_url)).to eq("http://location.request/dummy.cgi?my=#{callback_url}&pos=$location")
+    end
+  end
 end

--- a/test/rails/overrides/spec/requests/template_path_spec.rb
+++ b/test/rails/overrides/spec/requests/template_path_spec.rb
@@ -255,3 +255,17 @@ describe TemplatePathController, 'integrated_views', type: :request do
     end
   end
 end
+
+describe Jpmobile::Resolver::PathParser do
+  it 'locale と variant を持ち format と handler を省略したテンプレート名を解釈すること' do
+    parsed_path = described_class.new.parse('template_path/index.en+tablet')
+
+    aggregate_failures do
+      expect(parsed_path.path.to_s).to eq('template_path/index')
+      expect(parsed_path.details.locale).to eq(:en)
+      expect(parsed_path.details.variant).to eq(:tablet)
+      expect(parsed_path.details.format).to be_nil
+      expect(parsed_path.details.handler).to be_nil
+    end
+  end
+end

--- a/test/rails/overrides/spec/requests/trans_sid_spec.rb
+++ b/test/rails/overrides/spec/requests/trans_sid_spec.rb
@@ -140,6 +140,24 @@ describe 'trans_sid functional', type: :request do
       expect(controller.trans_sid_mode).to eq(:always)
     end
     it_should_behave_like 'trans_sid が起動するとき'
+
+    it '既存の query を保ったままセッション ID を redirect URL に追加すること' do
+      res = get_with_session(@controller, 'redirect_with_query', @user_agent)
+
+      expect(res.response.header['Location']).to match(%r{/destination\?source=mobile&_session_id=[a-zA-Z0-9]{32}$})
+    end
+
+    it 'セッション ID を含む redirect URL を上書きしないこと' do
+      res = get_with_session(@controller, 'redirect_with_session', @user_agent)
+
+      expect(res.response.header['Location']).to end_with('/destination?_session_id=preserved')
+    end
+
+    it 'セッション ID を含む redirect options を上書きしないこと' do
+      res = get_with_session(@controller, 'redirect_action_with_session', @user_agent)
+
+      expect(res.response.header['Location']).to end_with('/trans_sid_always/form?_session_id=preserved')
+    end
   end
 
   describe TransSidMetalController, 'という ActionController::Metal のコントローラ' do
@@ -199,5 +217,30 @@ describe 'trans_sid functional', type: :request do
 
   describe_mobile_with_ua 'Vodafone/1.0/V903T/TJ001 Browser/VF-Browser/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Ext-J-Profile/JSCL-1.2.2 Ext-V-Profile/VSCL-2.0.0', 'UTF-8' do
     it_should_behave_like 'trans_sid が起動しないとき'
+  end
+end
+
+describe Jpmobile::ParamsOverCookie do
+  let(:extractor_class) do
+    Class.new do
+      include Jpmobile::ParamsOverCookie
+
+      def initialize(key, cookie_only:)
+        @key = key
+        @cookie_only = cookie_only
+      end
+    end
+  end
+
+  it 'Cookie 専用でなければ URL のセッション ID を Cookie より優先すること' do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/?_session_id=url-session', 'HTTP_COOKIE' => '_session_id=cookie-session'))
+
+    expect(extractor_class.new('_session_id', cookie_only: false).extract_session_id(request)).to eq('url-session')
+  end
+
+  it 'Cookie 専用なら URL のセッション ID を受け入れないこと' do
+    request = Rack::Request.new(Rack::MockRequest.env_for('/?_session_id=url-session', 'HTTP_COOKIE' => '_session_id=cookie-session'))
+
+    expect(extractor_class.new('_session_id', cookie_only: true).extract_session_id(request)).to eq('cookie-session')
   end
 end


### PR DESCRIPTION
## 概要

Rails 統合まわりの 5 ファイルにテストを追加し、分岐カバレッジを 88.63% まで引き上げる。テストの追加のみで、`lib/` は変更していない。

## 背景

`helpers.rb` が、行カバレッジだけを見ていても穴が見えないことをよく表していた。101 行のうち 100 行は実行されているのに、32 分岐のうち通っていたのは 20 だけ。位置情報ヘルパーは `url_for` に渡す Hash と URL の直接指定の両方を受け取るが、テストされていたのは Hash 側だけで、**同じ未テスト分岐が 7 メソッドにコピーされていた**。

## 変更点

**helpers** — URL 直接指定の形を 8 メソッドまとめて確認する。それが重複の実体であるため。あわせてキャリア判定を追加し、DoCoMo 端末には FOMA GPS リンクだけが出ること、GPS も簡易位置情報も持たない端末には測位リンクが出ないことを確認する。

**request_with_mobile** — `remote_addr` は キャリア IP 判定の入力でありながら 6 分岐すべてが未実行だった。Rack 自身の `ip`、リバースプロキシの `X-Forwarded-For`、その後ろの `REMOTE_ADDR` を確認する。

**hankaku filter** — submit ボタンの value を本文とともに変換すること、Content-Type のない応答は変換しないこと、入れ子のフォームパラメータが階層を保つこと。

**trans_sid** — Cookie のみを受け付ける設定でなければ URL のセッション ID を優先すること、redirect に ID を追記する際に既存の query を壊さず、すでに ID があれば上書きしないこと。

**resolver** — locale と variant を持ち format と handler を省略したテンプレート名の解析。

trans_sid の redirect 経路を実リクエストで通すため、Rails テストアプリに 3 アクションと対応する route を追加している。既存の `redirect_path` / `redirect_action` と同じコントローラ・同じ routes 配列で、テスト専用の別実装ではない。

## 埋めなかった分岐

8 分岐は残した。

`filter.rb` の 4 つは手前で塞がれている。`to_external` は `mobile?` の判定を通ったときだけ呼ばれ、現存するキャリアはいずれも `default_charset` を返す。`String#encoding` が nil かを問う分岐は Ruby では成立しない。Rails の params は `each` に応答する。

`trans_sid.rb` の 2 つは request が無い場合への備えで、コメント自身が「for test process」と書いている。

最後の 1 つは `remote_addr` の Rails 側の腕。`ActionDispatch::Request` は `remote_addr` を actionpack 側の定義（`ENV_METHODS` の `class_eval`）で持つため、クラス自身のメソッドが include したモジュールより優先され、jpmobile の実装は実リクエストからは呼ばれない。ここを通すには `remote_ip` を持つ偽のオブジェクトを用意するしかなく、それは分岐を通すだけのテストになる。

## 効果

| 指標 | main | この PR |
|---|---|---|
| `helpers.rb` Branch | 20/32 (62.50%) | **32/32 (100%)** |
| `resolver.rb` Branch | 6/10 (60.00%) | **10/10 (100%)** |
| `trans_sid.rb` Branch | 22/30 (73.33%) | **27/30 (90.00%)** |
| `filter.rb` Branch | 25/34 (73.53%) | **30/34 (88.24%)** |
| `request_with_mobile.rb` Branch | 0/6 (0%) | **5/6 (83.33%)** |
| 全体 Line | 1816/1924 (94.39%) | **1831/1924 (95.17%)** |
| 全体 Branch | 499/598 (83.44%) | **530/598 (88.63%)** |

`helpers.rb` / `filter.rb` / `trans_sid.rb` / `resolver.rb` は行カバレッジ 100% に到達した。

## 検証

- `bundle exec rake coverage` … unit 394 (基準 388) / rack 152 (8 pending) / sinatra 6 / Rails 288 (基準 279)、失敗 0
- `bundle exec rubocop` … 164 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- `coverage/` を空にしてからの計測で、上記の数値と `lcov.info` (LF=1924 LH=1831 / BRF=598 BRH=530) が一致
