### PR TITLE
Cover the reachable branches that were left

### DIFF
--- a/spec/rack/jpmobile/filter_spec.rb
+++ b/spec/rack/jpmobile/filter_spec.rb
@@ -24,6 +24,19 @@ describe Jpmobile::Filter do
       end
 
       context 'Content-Type' do
+        it 'が charset のない空の HTML のときに charset を追加しないこと' do
+          res = Rack::MockRequest.env_for(
+            '/',
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_USER_AGENT' => 'DoCoMo/2.0 SH906i(c100;TB;W24H16)',
+            'Content-Type' => 'text/html',
+          )
+          res = Jpmobile::MobileCarrier.new(Jpmobile::Filter.new(UnitApplication.new(''))).call(res)
+
+          expect(res[1]['Content-Type']).to eq('text/html')
+          expect(response_body(res)).to be_empty
+        end
+
         it 'が application/xhtml+xml のときに変換されること' do
           res = Rack::MockRequest.env_for(
             '/',

--- a/spec/rack/jpmobile/params_filter_spec.rb
+++ b/spec/rack/jpmobile/params_filter_spec.rb
@@ -5,6 +5,17 @@ describe Jpmobile::ParamsFilter do
   include Jpmobile::RackHelper
   include Jpmobile::Util
 
+  it '空の区切りを無視し、値のない query parameter を保持すること' do
+    env = Rack::MockRequest.env_for(
+      '/?name=value&&flag',
+      'HTTP_USER_AGENT' => 'DoCoMo/2.0 SH906i(c100;TB;W24H16)',
+    )
+
+    _, filtered_env, = Jpmobile::MobileCarrier.new(described_class.new(UnitApplication.new)).call(env)
+
+    expect(filtered_env['QUERY_STRING']).to eq('name=value&flag=')
+  end
+
   context '漢字コード変換' do
     before(:each) do
       @query_params = {

--- a/spec/unit/position_spec.rb
+++ b/spec/unit/position_spec.rb
@@ -1,0 +1,19 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+
+describe Jpmobile::Position do
+  it '南半球・東経のケープタウンを方角付きで表すこと' do
+    position = described_class.new
+    position.lat = -33.9249
+    position.lon = 18.4241
+
+    expect(position.to_s).to match(/\AS.*E/)
+  end
+
+  it '北半球・西経のニューヨークを方角付きで表すこと' do
+    position = described_class.new
+    position.lat = 40.7128
+    position.lon = -74.0060
+
+    expect(position.to_s).to match(/\AN.*W/)
+  end
+end

--- a/test/rails/overrides/app/controllers/docomo_guid_none_controller.rb
+++ b/test/rails/overrides/app/controllers/docomo_guid_none_controller.rb
@@ -1,0 +1,3 @@
+class DocomoGuidNoneController < DocomoGuidBaseController
+  docomo_guid :none
+end

--- a/test/rails/overrides/app/controllers/docomo_guid_valid_ip_controller.rb
+++ b/test/rails/overrides/app/controllers/docomo_guid_valid_ip_controller.rb
@@ -1,0 +1,3 @@
+class DocomoGuidValidIpController < DocomoGuidBaseController
+  docomo_guid :valid_ip
+end

--- a/test/rails/overrides/config/routes.rb
+++ b/test/rails/overrides/config/routes.rb
@@ -44,6 +44,8 @@ RailsRoot::Application.routes.draw do
     docomo_guid_base
     docomo_guid_always
     docomo_guid_docomo
+    docomo_guid_none
+    docomo_guid_valid_ip
   ].each do |c|
     get "#{c}/link", to: "#{c}#link"
   end

--- a/test/rails/overrides/spec/controllers/docomo_guid_spec.rb
+++ b/test/rails/overrides/spec/controllers/docomo_guid_spec.rb
@@ -44,6 +44,31 @@ describe DocomoGuidAlwaysController, type: :controller do
   it_should_behave_like 'docomo_guid が起動するとき'
 end
 
+describe DocomoGuidNoneController, type: :controller do
+  before do
+    request.user_agent = 'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
+  end
+
+  it 'DoCoMo 端末でも guid=ON を付与しないこと' do
+    get :link
+
+    expect(response.body).not_to include('guid=ON')
+  end
+end
+
+describe DocomoGuidValidIpController, type: :controller do
+  before do
+    request.user_agent = 'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
+    request.env['REMOTE_ADDR'] = '127.0.0.1'
+  end
+
+  it 'DoCoMo の IP アドレス帯域外からは guid=ON を付与しないこと' do
+    get :link
+
+    expect(response.body).not_to include('guid=ON')
+  end
+end
+
 describe DocomoGuidDocomoController, type: :controller do
   before(:each) do
     request.user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; ja; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 ( .NET CLR 3.5.30729)'


### PR DESCRIPTION
## 概要

未カバーのまま残っていた 27 分岐を 14 ファイルにわたって洗い出し、到達できる 10 分岐にテストを追加した。残る 17 分岐は到達できない理由を確認して残している。テストの追加のみで、`lib/` は変更していない。

これで **分岐カバレッジ 90.30%**、未カバー 58 分岐すべてに理由が付いた状態になる。

## 変更点

**position** — 南半球の座標は `S`、西経の座標は `W` と表示される。既存の spec で使われていた座標はすべて北半球・東経で、この 4 分岐は一度も実行されていなかった。

**rack/filter** — charset を持たない Content-Type の応答に対して、charset を勝手に付け足さない。

**rack/params_filter** — `?name=value&&flag` のような query で、空の区切りを捨てつつ値のないパラメータを `flag=` として残す。

**docomo_guid** — `docomo_guid :none` と `:valid_ip`（DoCoMo の IP 帯域外から）では、どれだけ DoCoMo らしい User-Agent が来ても `guid=ON` を付けない。両設定の存在理由そのもの。

## 埋めなかった 17 分岐

内訳は次のとおり。

- **ロード時に一度だけ評価される（5）** — `$LOAD_PATH` のガード、キーがすべて Integer のテーブルから作る正規表現、ActionView にメソッドが無いときだけ張る delegate、`AbstractMobile` を含まないキャリア一覧、Geokit の include
- **boot する環境に依存する（3）** — Rails の環境判定、MemCacheStore と、それ以外の session store の経路
- **契約上ありえない入力への防御（5）** — Rack が禁じている nil、常に Hash である params、`to_str` にも `each` にも応答しない body、コントローラに必ずある request、単一の MIME type
- **SixApart のデータが要る（1）** — PC 絵文字の画像変換。リポジトリがそのデータを持たないため、rack spec が 2011 年から同じ理由で skip している経路
- **今の挙動が正しいとは言えない（3）** — 下記

## 見つかった実装の問題

作業中に 5 件見つかった。テストを書けば通せるものもあるが、書けば現在の誤った挙動を仕様として固定してしまうため、いずれも報告にとどめている。

1. **`Docomo` の測地系チェックが働いていない** — `unless geo.casecmp('wgs84')` は、`casecmp` が一致で `0`、不一致で `-1` / `1` を返し Ruby ではどちらも真なので、不正な測地系を渡しても例外にならない
2. **`PathSet` が resolver を二重の配列にする** — `PathSet.new([r]).paths` が `[r]` ではなく `[[r]]` を返す。`typecast` の `map` 内で引数なしの `super` が `paths` 全体を親へ渡すため
3. **fallback を有効にしても mobile view が選ばれない** — `index_mobile` が存在する状態で DoCoMo の UA からアクセスしても PC 側の view が返る
4. **Geokit の定数名が合っていない** — gem が定義するのは `Geokit` だが、コードは `GeoKit` を見ている。そのため `Mappable` の取り込みが行われない
5. **`to_s` が方角と負号を重ねて出す** — `S-33.924900E18.424100` のようになる。今回追加したテストは方角だけを見ており、この表記は固定していない

## 効果

| 指標 | main | この PR |
|---|---|---|
| Line | 1831/1924 (95.17%) | **1835/1924 (95.37%)** |
| Branch | 530/598 (88.63%) | **540/598 (90.30%)** |

## 検証

- `bundle exec rake coverage` … unit 396 / rack 154 (8 pending) / sinatra 6 / Rails 290、失敗 0
- `bundle exec rubocop` … 166 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- `coverage/` を空にしてからの計測で、上記の数値と `lcov.info` (LF=1924 LH=1835 / BRF=598 BRH=540) が一致
