### PR TITLE
Remove the Mail::Sendmail override that no longer runs

### DIFF
--- a/lib/jpmobile/mail.rb
+++ b/lib/jpmobile/mail.rb
@@ -632,22 +632,4 @@ module Mail
     alias_method :initialize_without_jpmobile, :initialize
     alias_method :initialize, :initialize_with_jpmobile
   end
-
-  class Sendmail
-    def self.call(path, arguments, destinations, mail)
-      encoded_mail = if mail.respond_to?(:encoded)
-                       mail.encoded
-                     else
-                       mail
-                     end
-      if Jpmobile::Util.jis?(encoded_mail)
-        encoded_mail = Jpmobile::Util.ascii_8bit(encoded_mail)
-      end
-
-      IO.popen("#{path} #{arguments} #{destinations}", 'w+') do |io|
-        io.puts encoded_mail.gsub("\r\r\n", "\n").to_lf
-        io.flush
-      end
-    end
-  end
 end

--- a/sig/jpmobile/mail.rbs
+++ b/sig/jpmobile/mail.rbs
@@ -269,8 +269,4 @@ module Mail
 
     alias initialize initialize_with_jpmobile
   end
-
-  class Sendmail
-    def self.call: (untyped path, untyped arguments, untyped destinations, untyped mail) -> untyped
-  end
 end


### PR DESCRIPTION
## 概要

15 年前から動かなくなっていた `Mail::Sendmail` の上書きを削除する。

## 背景

2011-02-25 の `cef29d8` で追加された。当時の mail gem は sendmail 配送を `Mail::Sendmail.call(path, arguments, destinations, mail)` というクラスメソッドで行っており、jpmobile はそこへ「本文が JIS なら `ascii_8bit` に落としてから渡す」という処置を挟んでいた。

その前提が両方とも失われている。

**配送の入口が変わった。** mail 2.8.1 は `Mail::Sendmail#deliver!`（インスタンスメソッド）で配送する。`.call` は呼ばれない。jpmobile を読み込む前は `Mail::Sendmail.respond_to?(:call)` が false で、読み込むと true になる。上書きしているのではなく、**誰も呼ばないクラスメソッドを足している**状態だった。

**`String#to_lf` が gem から消えた。** mail は `core_extensions/string.rb` の `String#to_lf` を廃止し `Mail::Utilities.binary_unsafe_to_lf` に置き換えた。jpmobile 側にこのメソッドの定義は履歴を通じて一度もない（`git log -S'def to_lf'` が空）。最後の行が `to_lf` を呼ぶため、仮に到達しても必ず `NoMethodError` になる。

リポジトリ内にこのクラスメソッドを参照するコードはない。安全なコマンドを与えて両方の引数パターンを実際に呼び出してみても、いずれも `NoMethodError` で止まる。

## 変更点

`lib/jpmobile/mail.rb` の `class Sendmail ... end` と、`sig/jpmobile/mail.rbs` の対応する定義を削除する。

sendmail 配送は以前から gem の実装だけで動いており、それは変わらない。無くなるのは「jpmobile がこの経路のエンコーディングを今も調整している」という見かけの方である。現在の `deliver!` に対してその調整を復活させるかどうかは別の判断であり、死んだコードの除去ではなく挙動の変更にあたる。

## 効果

| 指標 | 変更前 | 変更後 |
|---|---|---|
| Branch | 540/598 (90.30%) | **540/594 (90.91%)** |
| Line | 1835/1924 (95.37%) | **1833/1914 (95.77%)** |

未カバーだった 4 分岐が分母から消える。Line は分母が 10 減り、分子も 2 減る。`class` と `def` の行は require 時に実行済みとして数えられていたため。

## 検証

- `bundle exec rake coverage` … unit 396 / rack 154 (8 pending) / sinatra 6 / Rails 290、失敗 0
- `bundle exec rubocop` … 166 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
- 削除後も `Mail::Sendmail#deliver!` は mail gem の実装（`sendmail.rb:64`）を指したまま
