### PR TITLE
Fix fallback_view_selector never using a mobile view

### DIFF
--- a/lib/jpmobile/fallback_view_selector.rb
+++ b/lib/jpmobile/fallback_view_selector.rb
@@ -10,7 +10,7 @@ module Jpmobile
 
           _candidates = lookup_context.mobile.filter_map do |variant|
             target_template = options[:template] + '_' + variant
-            expected_view_file.virtual_path.match(target_template)
+            expected_view_file.identifier.match?(%r{/#{Regexp.escape(target_template)}\.[^/]+\z})
           end
 
           if _candidates.empty?

--- a/test/rails/overrides/app/controllers/template_path_controller.rb
+++ b/test/rails/overrides/app/controllers/template_path_controller.rb
@@ -13,6 +13,10 @@ class TemplatePathController < ApplicationController
   def partial
   end
 
+  def partial_only
+    render partial: 'template_path/partial'
+  end
+
   def optioned_index
     render action: 'index'
   end

--- a/test/rails/overrides/config/routes.rb
+++ b/test/rails/overrides/config/routes.rb
@@ -81,6 +81,7 @@ RailsRoot::Application.routes.draw do
     with_tblt
     with_ipd
     partial
+    partial_only
   ].each do |a|
     get "template_path/#{a}", to: "template_path##{a}"
   end

--- a/test/rails/overrides/spec/controllers/mobile_spec_controller_spec.rb
+++ b/test/rails/overrides/spec/controllers/mobile_spec_controller_spec.rb
@@ -24,6 +24,18 @@ describe MobileSpecController, type: :controller do
         expect(request.mobile?).to be_truthy
         expect(request.mobile).to be_a(Jpmobile::Mobile::Docomo)
       end
+
+      it 'uses the mobile view when fallback is enabled' do
+        original_value = Jpmobile.config.fallback_view_selector
+        Jpmobile.config.fallback_view_selector = true
+        request.user_agent = 'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
+
+        get 'index'
+
+        expect(response.body).to match(/RailsRoot mobile/)
+      ensure
+        Jpmobile.config.fallback_view_selector = original_value
+      end
     end
   end
 

--- a/test/rails/overrides/spec/requests/template_path_spec.rb
+++ b/test/rails/overrides/spec/requests/template_path_spec.rb
@@ -254,6 +254,47 @@ describe TemplatePathController, 'integrated_views', type: :request do
       end
     end
   end
+
+  context 'fallback_view_selector が有効な場合' do
+    around do |example|
+      original_value = Jpmobile.config.fallback_view_selector
+      Jpmobile.config.fallback_view_selector = true
+
+      example.run
+    ensure
+      Jpmobile.config.fallback_view_selector = original_value
+    end
+
+    context 'DoCoMoからのアクセスの場合' do
+      let(:user_agent) do
+        'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
+      end
+
+      it 'キャリア固有 view を使用すること' do
+        visit '/template_path/index'
+
+        expect(page).to have_content('index_mobile_docomo.html.erb')
+      end
+
+      it 'キャリア固有 partial を使用すること' do
+        visit '/template_path/partial_only'
+
+        expect(page).to have_content('_partial_mobile_docomo.html.erb')
+      end
+    end
+
+    context 'Androidからのアクセスの場合' do
+      let(:user_agent) do
+        'Mozilla/5.0 (Linux; U; Android 1.6; ja-jp; SonyEriccsonSO-01B Build/R1EA018) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'
+      end
+
+      it '利用可能な smart phone view へフォールバックすること' do
+        visit '/template_path/index'
+
+        expect(page).to have_content('index_smart_phone.html.erb')
+      end
+    end
+  end
 end
 
 describe Jpmobile::Resolver::PathParser do


### PR DESCRIPTION
## 概要

`fallback_view_selector` を有効にすると、モバイル用の view が存在していても必ず PC の view が使われていた。モバイル用の view が**無いとき**にだけ PC へ落とす、という機能の意図と逆になっていた。

## 原因

判定はこう書かれていた。

```ruby
expected_view_file = lookup_context.find_template(options[:template], options[:prefixes])

_candidates = lookup_context.mobile.filter_map do |variant|
  target_template = options[:template] + '_' + variant     # "template_path/index_mobile"
  expected_view_file.virtual_path.match(target_template)
end

if _candidates.empty?
  lookup_context.mobile = []
end
```

見つかったテンプレートがモバイル用かどうかを `virtual_path` で判定している。ところが jpmobile の `Resolver::PathParser` は `_mobile` サフィックスを独立したキャプチャとして取り出し、残りから `TemplatePath` を組み立てる。

```
template_path/index_mobile.html.erb -> virtual_path = template_path/index
template_path/index.html.erb        -> virtual_path = template_path/index
```

どちらも同じ値になるため `match` は決して成立せず、候補は毎回空になり、レンダリングに渡る前に variant が捨てられていた。

## 変更点

`identifier` を見るようにした。resolver が実際に選んだファイルのパスなので、サフィックスがそのまま残っている。探索順は変えていないので、`mobile_docomo` が `mobile` より優先されることも従来どおり。

判定はパス末尾のファイル名に固定し、テンプレート名は `Regexp.escape` する。`identifier` はフルパスなので、アンカーを置かないと `index_mobile` という名前のディレクトリを「その view 自体がモバイル用である」証拠として拾ってしまう。

```ruby
expected_view_file.identifier.match?(%r{/#{Regexp.escape(target_template)}\.[^/]+\z})
```

ロケール付き（`index_mobile.ja.html.erb`）や variant 付き（`index_mobile.html+tablet.erb`）のファイル名にも一致し、`index_mobile_docomo.html.erb` を `index_mobile` の一致とみなす取り違えも起きない。

## なぜ気づかれなかったか

この機能に対する既存の spec は `mobile_not_exist`、つまりモバイル版を持たないテンプレートだけを対象にしていた。それは正しく動いていた側で、壊れている側は一度も確認されていなかった。

反対側を追加した。

- モバイル用の view があればそれが使われる
- キャリア固有のものが汎用のものより優先される
- 先頭の variant が無ければ PC ではなく次の候補へ落ちる
- partial でも同じ扱いになる

修正を戻すと、このうち 3 例が失敗する。

## 効果

| 指標 | 変更前 | 変更後 |
|---|---|---|
| `lib/jpmobile/fallback_view_selector.rb` Branch | 3/4 | **4/4** |
| 全体 Branch | 540/598 | **541/598** |

## 補足

PC の親テンプレートへフォールバックすると、その配下の partial の探索からも variant が消える。`lookup_context.mobile = []` がリクエストの LookupContext を空にするためで、フォールバックがテンプレート単位ではなくページ単位で効くという現在の設計の帰結にあたる。この PR では変えていない。

`fallback_view_selector` は README に記載がなく、設定の存在も既定値（false）も利用者からは分からない。ドキュメントの追加は別途。

## 検証

- `bundle exec rake coverage` … unit 396 / rack 154 (8 pending) / sinatra 6 / Rails 294、失敗 0
- `bundle exec rubocop` … 166 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
