### PR TITLE
Stop a request spec from launching a browser it never uses

### DIFF
--- a/test/rails/overrides/spec/requests/filter_spec.rb
+++ b/test/rails/overrides/spec/requests/filter_spec.rb
@@ -1,11 +1,7 @@
-require 'system_helper'
+require 'rails_helper'
 
 describe 'jpmobile integration spec', type: :request do
   include Jpmobile::Util
-
-  before do
-    page.driver.headers = { 'User-Agent' => user_agent }
-  end
 
   shared_examples_for '文字コードフィルタが動作しているとき' do
     it 'はhtml以外は変換しないこと' do


### PR DESCRIPTION
## 概要

`spec/requests/filter_spec.rb` が、使いもしないヘッドレスブラウザを example ごとに起動していた。これを止める。

## 背景

CI がこの 1 例で繰り返し落ちていた。

```
Failure/Error: page.driver.headers = { 'User-Agent' => user_agent }
Ferrum::ProcessTimeoutError:
  Browser did not produce websocket url within 10 seconds
```

| 実行 | ブランチ | 結果 |
|---|---|---|
| 2026-08-24 09:26 | main | 同じ箇所で失敗 |
| 2026-08-25 02:19 | #517 | 同じ箇所で失敗（再実行で通した） |
| 2026-08-25 02:37 | #518 | 同じ箇所で失敗（再実行で通した） |

`before` ブロックが Capybara のドライバに触れるため、example ごとに Chrome が起動する。CI ではその起動が ferrum の 10 秒を超えることがある。

## 変更点

このファイルにブラウザは要らない。全 example は `get` に `env: { 'HTTP_USER_AGENT' => user_agent }` で UA を渡し、`response` だけを見る。`page` が出てくるのは `before` のこの 1 行だけで、設定したヘッダはどこにも効いていない。

他の 8 つの request spec は `rails_helper` を読み、何も起動しない。ここも同じにして `before` を落とす。

## 効果

| 指標 | 変更前 | 変更後 |
|---|---|---|
| ファイル単独実行 | 1.902 秒 | 1.412 秒 |
| example 実行時間 | 0.4731 秒 | 0.06987 秒 |

Puma と Capybara server の起動ログが消える。10 examples は変更前後とも通る。

UA が env 経由でキャリア判定に届いていることも確認した（PC → nil、DoCoMo → `Jpmobile::Mobile::Docomo`、au → `Au`、SoftBank → `Softbank`）。

## この PR で解決しないこと

**CI のブラウザ起動そのものが無くなるわけではない。**

`spec/requests/template_path_spec.rb` にも同じ `page.driver.headers` があり、こちらは `visit` と page matcher を実際に使っている。`cuprite_setup.rb` が `Capybara.default_driver` を `:cuprite` にするため、`spec/system` を含むフルスイートではこのファイルも Chrome を起動する。したがって同じ `ProcessTimeoutError` がそちらへ移る可能性がある。

そのファイルは request API（`get` と `response`）へ移せるはずで、別の PR で扱う。それでも `spec/system` の 2 ファイルは本当にブラウザを必要とするので、Chrome 起動自体は最終的に残る。`process_timeout` を延ばすかどうかは、request spec をブラウザから切り離したあとの実測を見てから判断するのが妥当と考えている。

## 検証

- `bundle exec rake coverage` … unit 396 / rack 154 (8 pending) / sinatra 6 / Rails 294、失敗 0
- `bundle exec rubocop` … 166 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
