### PR TITLE
Drive the template path specs through the request API

### DIFF
--- a/test/rails/overrides/spec/requests/template_path_spec.rb
+++ b/test/rails/overrides/spec/requests/template_path_spec.rb
@@ -1,19 +1,15 @@
 require 'rails_helper'
 
 describe TemplatePathController, 'integrated_views', type: :request do
-  before do
-    page.driver.headers = { 'User-Agent' => user_agent }
-  end
-
   describe 'index' do
     context 'PCからのアクセスの場合' do
       let(:user_agent) do
         'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)'
       end
       it 'index.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index.html.erb')
+        expect(response.body).to include('index.html.erb')
       end
     end
 
@@ -22,21 +18,21 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
       end
       it 'index_mobile_docomo.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index_mobile_docomo.html.erb')
+        expect(response.body).to include('index_mobile_docomo.html.erb')
       end
 
       it 'show.html.erb がなくとも show_mobile_docomo.html.erbが使用されること' do
-        visit '/template_path/show'
+        get '/template_path/show', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('show_mobile_docomo.html.erb')
+        expect(response.body).to include('show_mobile_docomo.html.erb')
       end
 
       it 'disable_mobile_view! のときには index.html.erb が使用されること' do
-        visit '/template_path/index?pc=true'
+        get '/template_path/index?pc=true', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index.html.erb')
+        expect(response.body).to include('index.html.erb')
       end
     end
 
@@ -45,15 +41,15 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'SoftBank/1.0/910T/TJ001/SN000000000000000 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1'
       end
       it 'index_mobile.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index_mobile.html.erb')
+        expect(response.body).to include('index_mobile.html.erb')
       end
 
       it 'show.html.erb がなくとも show_mobile.html.erbが使用されること' do
-        visit '/template_path/show'
+        get '/template_path/show', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('show_mobile.html.erb')
+        expect(response.body).to include('show_mobile.html.erb')
       end
     end
 
@@ -62,9 +58,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; ja-jp) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16'
       end
       it 'smart_phone_iphone.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('smart_phone_iphone.html.erb')
+        expect(response.body).to include('smart_phone_iphone.html.erb')
       end
     end
 
@@ -73,9 +69,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (Linux; U; Android 1.6; ja-jp; SonyEriccsonSO-01B Build/R1EA018) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'
       end
       it 'smart_phone.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('smart_phone.html.erb')
+        expect(response.body).to include('smart_phone.html.erb')
       end
     end
 
@@ -84,9 +80,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/4.0 (Compatible; MSIE 6.0; Windows NT 5.1 T-01A_6.5; Windows Phone 6.5)'
       end
       it 'smart_phone.html.erbが使用されること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('smart_phone.html.erb')
+        expect(response.body).to include('smart_phone.html.erb')
       end
     end
   end
@@ -97,9 +93,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (iPad; U; CPU OS 4_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8F191 Safari/6533.18.5'
       end
       it 'smart_phone_only.html.erbが使用されること' do
-        visit '/template_path/smart_phone_only'
+        get '/template_path/smart_phone_only', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('smart_phone_only_smart_phone.html.erb')
+        expect(response.body).to include('smart_phone_only_smart_phone.html.erb')
       end
     end
 
@@ -108,9 +104,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (Linux; U; Android 2.2; ja-jp; SC-01C Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
       end
       it 'smart_phone_only.html.erbが使用されること' do
-        visit '/template_path/smart_phone_only'
+        get '/template_path/smart_phone_only', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('smart_phone_only_smart_phone.html.erb')
+        expect(response.body).to include('smart_phone_only_smart_phone.html.erb')
       end
     end
   end
@@ -121,9 +117,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (iPad; U; CPU OS 4_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8F191 Safari/6533.18.5'
       end
       it 'with_tblt_tablet.html.erbが使用されること' do
-        visit '/template_path/with_tblt'
+        get '/template_path/with_tblt', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('with_tblt_tablet.html.erb')
+        expect(response.body).to include('with_tblt_tablet.html.erb')
       end
     end
 
@@ -132,9 +128,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (Linux; U; Android 2.2; ja-jp; SC-01C Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
       end
       it 'with_tblt_tablet.html.erbが使用されること' do
-        visit '/template_path/with_tblt'
+        get '/template_path/with_tblt', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('with_tblt_tablet.html.erb')
+        expect(response.body).to include('with_tblt_tablet.html.erb')
       end
     end
   end
@@ -145,9 +141,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (iPad; U; CPU OS 4_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8F191 Safari/6533.18.5'
       end
       it 'with_ipd_tablet_ipad.html.erbが使用されること' do
-        visit '/template_path/with_ipd'
+        get '/template_path/with_ipd', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('with_ipd_tablet_ipad.html.erb')
+        expect(response.body).to include('with_ipd_tablet_ipad.html.erb')
       end
     end
 
@@ -156,9 +152,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (Linux; U; Android 2.2; ja-jp; SC-01C Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
       end
       it 'with_ipd.html.erbが使用されること' do
-        visit '/template_path/with_ipd'
+        get '/template_path/with_ipd', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('with_ipd.html.erb')
+        expect(response.body).to include('with_ipd.html.erb')
       end
     end
   end
@@ -169,9 +165,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)'
       end
       it '_partial.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial.html.erb')
+        expect(response.body).to include('_partial.html.erb')
       end
     end
 
@@ -180,9 +176,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
       end
       it '_partial_mobile_docomo.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_mobile_docomo.html.erb')
+        expect(response.body).to include('_partial_mobile_docomo.html.erb')
       end
     end
 
@@ -191,9 +187,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'SoftBank/1.0/910T/TJ001/SN000000000000000 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1'
       end
       it '_partial_mobile.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_mobile.html.erb')
+        expect(response.body).to include('_partial_mobile.html.erb')
       end
     end
 
@@ -202,9 +198,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; ja-jp) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16'
       end
       it '_partial_smart_phone_iphone.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_smart_phone_iphone.html.erb')
+        expect(response.body).to include('_partial_smart_phone_iphone.html.erb')
       end
     end
 
@@ -213,9 +209,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/5.0 (Linux; U; Android 1.6; ja-jp; SonyEriccsonSO-01B Build/R1EA018) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'
       end
       it '_partial_smart_phone.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_smart_phone.html.erb')
+        expect(response.body).to include('_partial_smart_phone.html.erb')
       end
     end
 
@@ -224,9 +220,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/4.0 (Compatible; MSIE 6.0; Windows NT 5.1 T-01A_6.5; Windows Phone 6.5)'
       end
       it '_partial_smart_phone.html.erbが使用されること' do
-        visit '/template_path/partial'
+        get '/template_path/partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_smart_phone.html.erb')
+        expect(response.body).to include('_partial_smart_phone.html.erb')
       end
     end
   end
@@ -237,9 +233,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)'
       end
       it '_partial.html.erbが使用されること' do
-        visit '/template_path/full_path_partial'
+        get '/template_path/full_path_partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial.html.erb')
+        expect(response.body).to include('_partial.html.erb')
       end
     end
 
@@ -248,9 +244,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
         'DoCoMo/2.0 SH902i(c100;TB;W24H12)'
       end
       it '_partial_mobile_docomo.html.erbが使用されること' do
-        visit '/template_path/full_path_partial'
+        get '/template_path/full_path_partial', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_mobile_docomo.html.erb')
+        expect(response.body).to include('_partial_mobile_docomo.html.erb')
       end
     end
   end
@@ -271,15 +267,15 @@ describe TemplatePathController, 'integrated_views', type: :request do
       end
 
       it 'キャリア固有 view を使用すること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index_mobile_docomo.html.erb')
+        expect(response.body).to include('index_mobile_docomo.html.erb')
       end
 
       it 'キャリア固有 partial を使用すること' do
-        visit '/template_path/partial_only'
+        get '/template_path/partial_only', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('_partial_mobile_docomo.html.erb')
+        expect(response.body).to include('_partial_mobile_docomo.html.erb')
       end
     end
 
@@ -289,9 +285,9 @@ describe TemplatePathController, 'integrated_views', type: :request do
       end
 
       it '利用可能な smart phone view へフォールバックすること' do
-        visit '/template_path/index'
+        get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
 
-        expect(page).to have_content('index_smart_phone.html.erb')
+        expect(response.body).to include('index_smart_phone.html.erb')
       end
     end
   end


### PR DESCRIPTION
## 概要

`spec/requests/template_path_spec.rb` を Capybara から Rails の request API へ移す。

## 背景

このファイルは `before` でドライバにヘッダを設定し、各 example が `visit` を呼び、`page` に対して内容を確認していた。しかしブラウザは要らない。確認しているのは「どのテンプレートが選ばれたか」で、その名前は本文に出力されている。

この依存が二重に効いていた。

**フルスイートでブラウザが起動する。** `spec/system` が `cuprite_setup` を読み込み、それがプロセス全体の既定ドライバを cuprite にする。このファイルが `page.driver` に触れた瞬間に Puma と Chrome が立ち上がる。CI でタイムアウトしていたのと同じ起動である。

**単独では実行できない。** RackTest ドライバは `headers=` を持たないため、27 例のうち 26 例が検証にたどり着く前に落ちる。`spec/system` が同居することで偶然動いていた。

## 変更点

`get` でリクエストを発行し、User-Agent は他の request spec と同じく `env` で渡す。検証は `response.body` に対して行う。example の数、記述、それぞれが確認している内容は変えていない。

```ruby
- visit '/template_path/index'
- expect(page).to have_content('index_mobile_docomo.html.erb')
+ get '/template_path/index', env: { 'HTTP_USER_AGENT' => user_agent }
+ expect(response.body).to include('index_mobile_docomo.html.erb')
```

`Resolver::PathParser` の describe は Capybara を使っていないのでそのまま。

## 効果

| 条件 | 変更前 | 変更後 |
|---|---|---|
| 単独実行 | 27 例中 **26 failures** | **27 examples / 0 failures** |
| `cuprite_setup` 同時ロード | 27/0（Puma + Chrome 起動） | **27/0、Puma 起動なし** |
| 所要時間（同時ロード時） | 3.999 秒 / RSpec 2.57 秒 | 1.561 秒 / RSpec 0.162 秒 |

所要時間は 1 サンプルの参考値。

## 検証の同一性

`have_content` は表示テキストを見て空白を正規化し、`include` は本文に対する部分文字列一致になる。fixture はファイル名を h1 / h2 の本文としてそのまま出しており、script やタグの属性、コメントにファイル名は現れない。

期待する文字列どうしで包含関係があるもの（`smart_phone.html.erb` が `index_smart_phone.html.erb` に含まれる等）は移行前から同じ部分一致で、判定は変わっていない。Android の例で PC の `index.html.erb` に落ちれば、その文字列を含まないので失敗する。

## 残る話

`spec/system` の 2 ファイルは実際にブラウザを必要とするので、フルスイートでの Chrome 起動そのものは残る。#519 と合わせて、request spec が余計にブラウザを起こすことは無くなった。

## 検証

- `bundle exec rake coverage` … unit 396 / rack 154 (8 pending) / sinatra 6 / Rails 294、失敗 0
- `bundle exec rubocop` … 166 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error
