### PR TITLE
Hand one path at a time to PathSet's parent typecast

### DIFF
--- a/lib/jpmobile/path_set.rb
+++ b/lib/jpmobile/path_set.rb
@@ -8,7 +8,7 @@ module Jpmobile
         when Pathname, String
           Jpmobile::Resolver.new path.to_s
         else
-          super
+          super([path]).first
         end
       end
     end

--- a/spec/unit/path_set_spec.rb
+++ b/spec/unit/path_set_spec.rb
@@ -1,0 +1,26 @@
+require 'action_view'
+require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+
+describe Jpmobile::PathSet do
+  it 'Resolver をそのまま保持すること' do
+    resolver = Jpmobile::Resolver.new('/tmp/views')
+
+    expect(described_class.new([resolver]).paths).to eq([resolver])
+  end
+
+  it '文字列のパスを Jpmobile::Resolver に変換すること' do
+    paths = described_class.new(['/tmp/views']).paths
+
+    expect(paths).to contain_exactly(an_instance_of(Jpmobile::Resolver))
+  end
+
+  it '不正な型には親と同じ TypeError を送出すること' do
+    parent_error = begin
+      ActionView::PathSet.new([1])
+    rescue TypeError => e
+      e
+    end
+
+    expect { described_class.new([1]) }.to raise_error(TypeError, parent_error.message)
+  end
+end


### PR DESCRIPTION
## 概要

`Jpmobile::PathSet` に resolver を渡すと、二重の配列になって返っていた。

```ruby
Jpmobile::PathSet.new([resolver]).paths     # => [[resolver]]
ActionView::PathSet.new([resolver]).paths   # => [resolver]
```

## 原因

`typecast` は String と Pathname を jpmobile の resolver に変え、それ以外は ActionView に任せている。

```ruby
def typecast(paths)
  paths.map do |path|
    case path
    when Pathname, String
      Jpmobile::Resolver.new path.to_s
    else
      super          # ← paths が渡る
    end
  end
end
```

引数を書かない `super` は、そのメソッドが受け取った引数をそのまま渡す。ここで渡っているのは変換しようとしている `path` ではなく `paths`、つまり配列全体になる。親は受け取った配列を `map` して配列を返すので、その結果が `map` のブロックの戻り値になり、要素が配列になっていた。

## 変更点

処理中の 1 つだけを、親が期待する配列の形のまま渡し、結果の 1 件を取る。

```ruby
super([path]).first
```

resolver をそのまま通すのか、それ以外を `TypeError` で弾くのかという判断は ActionView 側に残したままにする。こちらへ写すと親の変更に追随できなくなる。

## 影響

jpmobile の中でこのクラスを使っているのは 1 箇所だけで、

```ruby
# lib/jpmobile/view_selector.rb
self.view_paths = Jpmobile::PathSet.new(self.view_paths.paths.map(&:path))
```

`.map(&:path)` が必ず文字列を渡すため `else` に入らない。そのため気づかれずにいた。resolver を直接渡す使い方をしたときだけ表に出る。

## テスト

`PathSet` の spec が無かったので追加した。

- resolver がそのまま保たれること — 修正前は `[[resolver]]` になり落ちる
- 文字列が `Jpmobile::Resolver` に変換されること
- 不正な型に対して親と同じ `TypeError` が出ること

3 つ目は、親と同じ入力を `ActionView::PathSet` に与えて得た例外のメッセージと突き合わせる。この不具合自体は検出しないが（修正前も配列 `[1]` が渡るので同じ例外になる）、`else` が親へ委譲しているという関係を固定する。

## 検証

- `bundle exec rake coverage` … unit 399 / rack 154 (8 pending) / sinatra 6 / Rails 294、失敗 0
- `bundle exec rubocop` … 167 files, no offenses
- `bundle exec rbs validate` … 成功
- `bundle exec steep check` … No type error

| 指標 | 変更前 | 変更後 |
|---|---|---|
| `lib/jpmobile/path_set.rb` Branch | 1/2 | **2/2** |
| 全体 Line | 1833/1914 | **1834/1914 (95.82%)** |
| 全体 Branch | 541/594 | **542/594 (91.25%)** |
